### PR TITLE
Refactor color message utilities and increase embedding text limit

### DIFF
--- a/litassist/utils.py
+++ b/litassist/utils.py
@@ -524,7 +524,7 @@ def create_embeddings(texts: List[str]) -> List[Any]:
     from litassist.config import CONFIG
 
     # Validate text lengths (8191 tokens ≈ 32000 chars for safety)
-    MAX_CHARS = 64000
+    MAX_CHARS = 32000
     for i, text in enumerate(texts):
         if len(text) > MAX_CHARS:
             raise ValueError(


### PR DESCRIPTION
- Improve code readability in color message functions by adding spacing and consistent formatting
- Double MAX_CHARS limit for create_embeddings from 32,000 to 64,000 to support longer texts
- Use consistent string quoting and minor style fixes throughout for clarity and maintainability