### PR TITLE
feat(lookup): add AustLII CSE and expand comprehensive search

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,8 @@ litassist lookup "elements of contract breach and damages" --mode irac --compreh
    Options:
    - `--mode [irac|broad]`: Analysis format (default: irac)
    - `--extract [citations|principles|checklist]`: Extract specific information in structured format
-   - `--comprehensive`: Adds results from an additional "comprehensive" CSE (up to
-     10 extra sources) for an exhaustive analysis. Jade and AustLII searches are
-     always performed when their CSE IDs are configured.
+   - `--comprehensive`: Adds up to 10 extra sources from a "comprehensive" CSE for an
+     exhaustive analysis, in addition to standard Jade and AustLII searches.
 
 ### 3. digest - Process large documents for summaries or issues
 

--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ litassist lookup "elements of contract breach and damages" --mode irac --compreh
    Options:
    - `--mode [irac|broad]`: Analysis format (default: irac)
    - `--extract [citations|principles|checklist]`: Extract specific information in structured format
-   - `--comprehensive`: Adds up to 10 extra sources from a "comprehensive" CSE for an
-     exhaustive analysis, in addition to standard Jade and AustLII searches.
+   - `--comprehensive`: Enable comprehensive mode: standard searches yield up to 5
+     results each from Jade and AustLII; comprehensive mode yields up to 10 results
+     each from Jade, AustLII, and a secondary CSE.
 
 ### 3. digest - Process large documents for summaries or issues
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ openai:
   embedding_model:  "text-embedding-3-small"
 
 google_cse:
-  api_key:  "YOUR_GOOGLE_API_KEY"
-  cse_id:   "YOUR_JADE_CSE_ID"    # Google CSE for Jade.io
+  api_key:                "YOUR_GOOGLE_API_KEY"         # API key for Google Custom Search
+  cse_id:                 "YOUR_JADE_CSE_ID"           # Google CSE for Jade.io
+  cse_id_comprehensive:   "YOUR_COMPREHENSIVE_CSE_ID"  # Optional: broader legal sources (gov.au etc.)
+  cse_id_austlii:         "YOUR_AUSTLII_CSE_ID"        # Optional: AustLII CSE for Australian legal cases
 
 pinecone:
   api_key:     "YOUR_PINECONE_KEY"

--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ litassist lookup "elements of contract breach and damages" --mode irac --compreh
    Options:
    - `--mode [irac|broad]`: Analysis format (default: irac)
    - `--extract [citations|principles|checklist]`: Extract specific information in structured format
-   - `--comprehensive`: Use exhaustive analysis with up to 40 sources (vs 5 standard)
+   - `--comprehensive`: Adds results from an additional "comprehensive" CSE (up to
+     10 extra sources) for an exhaustive analysis. Jade and AustLII searches are
+     always performed when their CSE IDs are configured.
 
 ### 3. digest - Process large documents for summaries or issues
 

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -14,6 +14,7 @@ google_cse:
   api_key:  "YOUR_GOOGLE_API_KEY"
   cse_id:   "YOUR_JADE_CSE_ID"    # Google CSE ID for searching Jade.io legal database
   cse_id_comprehensive: "YOUR_COMPREHENSIVE_CSE_ID"  # Optional: CSE ID for broader legal sources (austlii.edu.au, *.gov.au, etc.)
+  cse_id_austlii:          "YOUR_AUSTLII_CSE_ID"      # Optional: CSE ID for searching AustLII database
 
 pinecone:
   api_key:     "YOUR_PINECONE_KEY"

--- a/docs/user/Google CSE setup.md
+++ b/docs/user/Google CSE setup.md
@@ -18,8 +18,8 @@
 4. **Quota considerations**
 
    * Free tier = **100 requests/day**. Each `lookup` run uses:
-     - Standard mode: **1 API call** (5 results from Jade.io)
-     - Comprehensive mode: **2 API calls** (up to 20 results from Jade.io) + **1 additional call** if secondary CSE configured (up to 10 broader legal sources)
+     - Standard mode: **2 API calls** (5 results each from Jade.io and AustLII CSE if configured)
+     - Comprehensive mode: **3 API calls** (10 results each from Jade.io, AustLII CSE if configured, and secondary CSE)
    * Raise quota in Google Cloud if you need more.
 
 5. **Billing (optional)**
@@ -46,7 +46,9 @@ google_cse:
 
 the **lookup** command will automatically:
 
-1. Query Google CSE for legal sources (default: 5 Jade.io sources, comprehensive: up to 20 Jade.io + 10 broader sources).
+1. Query Google CSE for legal sources:
+   - Standard: up to 5 Jade.io + 5 AustLII sources
+   - Comprehensive: up to 10 Jade.io + 10 AustLII + 10 broader sources
 2. Feed the links into **Gemini 2.5 Pro**.
 3. Return an IRAC-style answer with citations.
 
@@ -70,8 +72,9 @@ To enable broader legal searches beyond Jade.io when using `--comprehensive`:
 4. **Use the same API key** - no need for a separate key
 
 When configured, the `--comprehensive` flag will search both:
-- **Primary CSE**: Up to 20 Jade.io sources for authoritative case law
-- **Secondary CSE**: 10 additional sources from government, courts, and academic sites
+- **Primary CSE (Jade)**: Up to 10 Jade.io sources
+- **AustLII CSE**: Up to 10 AustLII sources
+- **Secondary CSE**: Up to 10 additional sources from government, courts, and academic sites
 
 ---
 
@@ -80,12 +83,12 @@ When configured, the `--comprehensive` flag will search both:
 The lookup command supports a `--comprehensive` flag for exhaustive analysis:
 
 ```bash
-# Standard search (5 sources)
+# Standard search (up to 5 Jade.io + 5 AustLII sources)
 litassist lookup "contract formation elements"
 
-# Comprehensive search (up to 20 Jade.io + 10 broader sources if secondary CSE configured)
+# Comprehensive search (up to 10 Jade.io + 10 AustLII + 10 broader sources)
 litassist lookup "contract formation elements" --comprehensive
-```
+``` 
 
 **Note**: Comprehensive mode uses significantly more API calls. Consider your daily quota when using this feature.
 

--- a/litassist/commands/lookup.py
+++ b/litassist/commands/lookup.py
@@ -39,7 +39,7 @@ warnings.filterwarnings("ignore", message=".*file_cache.*")
 @click.option(
     "--comprehensive",
     is_flag=True,
-    help="Use exhaustive analysis with maximum sources (40 instead of 5)",
+    help="Use comprehensive analysis with multiple sources (10 Jade, 10 AustLII, 10 broader CSE)",
 )
 @click.option(
     "--context",
@@ -61,80 +61,55 @@ def lookup(question, mode, extract, comprehensive, context):
               structured analysis, or 'broad' for more creative exploration.
         extract: Extract specific information - 'citations' for case references,
                 'principles' for legal rules, or 'checklist' for practical items.
-        comprehensive: Use exhaustive analysis with 20 sources instead of 5.
+        comprehensive: Use comprehensive analysis with multiple sources (10 Jade, 10 AustLII, 10 broader CSE).
 
     Raises:
         click.ClickException: If there are errors with the search or LLM API calls.
     """
-    # Determine search parameters based on comprehensive flag
-    if comprehensive:
-        max_sources = 20
-    else:
-        max_sources = 5
-
-    # Fetch case links using Jade CSE
+    # Fetch case links using configured Custom Search Engines
     try:
         from googleapiclient.discovery import build
 
         service = build(
             "customsearch", "v1", developerKey=CONFIG.g_key, cache_discovery=False
         )
-
-        if comprehensive:
-            # Comprehensive Jade CSE search - 2 calls for 20 results
-            all_links = []
-            queries = [
-                question,
-                f"{question} case law",
-            ]
-
-            for query in queries:
-                res = (
-                    service.cse()
-                    .list(
-                        q=query, cx=CONFIG.cse_id
-                    )
-                    .execute()
-                )
-                all_links.extend([item.get("link") for item in res.get("items", [])])
-
-            # Remove duplicates while preserving order
-            seen = set()
-            links = []
-            for link in all_links:
-                if link and link not in seen:
-                    seen.add(link)
-                    links.append(link)
-                    if len(links) >= max_sources:
-                        break
-        else:
-            # Standard Jade CSE search
-            res = (
-                service.cse()
-                .list(
-                    q=question, cx=CONFIG.cse_id
-                )
-                .execute()
-            )
-            links = [item.get("link") for item in res.get("items", [])][:max_sources]
-
     except Exception as e:
-        raise click.ClickException(f"Search error: {e}")
+        raise click.ClickException(f"Search initialization error: {e}")
 
-    # Add comprehensive CSE search if configured
-    if comprehensive and CONFIG.cse_id_comprehensive:
+    links = []
+    # Jade CSE search (primary)
+    jade_limit = 10
+    try:
+        res_jade = service.cse().list(q=question, cx=CONFIG.cse_id, num=jade_limit).execute()
+        jade_links = [item.get("link") for item in res_jade.get("items", [])][:jade_limit]
+        links.extend(jade_links)
+    except Exception as e:
+        raise click.ClickException(f"Jade CSE search error: {e}")
+
+    # AustLII CSE search (optional)
+    austlii_id = getattr(CONFIG, "cse_id_austlii", None)
+    if isinstance(austlii_id, str) and austlii_id:
+        aus_limit = 10
         try:
-            # Reuse the service instance for the comprehensive search
-            res_comp = (
-                service.cse()
-                .list(q=question, cx=CONFIG.cse_id_comprehensive)
-                .execute()
-            )
-            links.extend([item.get("link") for item in res_comp.get("items", [])])
+            res_aus = service.cse().list(q=question, cx=austlii_id, num=aus_limit).execute()
+            aus_links = [item.get("link") for item in res_aus.get("items", [])][:aus_limit]
+            links.extend(aus_links)
         except Exception as e:
-            click.echo(f"Warning: Secondary CSE search failed: {e}")
-            logging.exception("Secondary CSE search failed", exc_info=e)
-            # Continue with existing links from primary search
+            click.echo(f"Warning: AustLII CSE search failed: {e}")
+            logging.exception("AustLII CSE search failed", exc_info=e)
+
+    # Comprehensive CSE search (optional, only for comprehensive mode)
+    if comprehensive:
+        comp_id = getattr(CONFIG, "cse_id_comprehensive", None)
+        if isinstance(comp_id, str) and comp_id:
+            comp_limit = 10
+            try:
+                res_comp = service.cse().list(q=question, cx=comp_id, num=comp_limit).execute()
+                comp_links = [item.get("link") for item in res_comp.get("items", [])][:comp_limit]
+                links.extend(comp_links)
+            except Exception as e:
+                click.echo(f"Warning: Secondary CSE search failed: {e}")
+                logging.exception("Secondary CSE search failed", exc_info=e)
 
     # Display found links
     click.echo("Found links:")

--- a/litassist/commands/lookup.py
+++ b/litassist/commands/lookup.py
@@ -25,6 +25,22 @@ from litassist.prompts import PROMPTS
 os.environ["GOOGLE_API_USE_CLIENT_CERTIFICATE"] = "false"
 warnings.filterwarnings("ignore", message=".*file_cache.*")
 
+def _perform_cse_search(service, query, cse_id, limit, primary=False):
+    """Perform a Google Custom Search Engine lookup and return a list of links."""
+    if not cse_id:
+        return []
+    try:
+        res = service.cse().list(q=query, cx=cse_id, num=limit).execute()
+        items = res.get("items", [])
+        return [item.get("link") for item in items]
+    except Exception as e:
+        msg = f"CSE search failed for '{cse_id}': {e}"
+        if primary:
+            raise click.ClickException(msg)
+        click.echo(f"Warning: {msg}")
+        logging.exception(msg, exc_info=e)
+        return []
+
 
 
 
@@ -39,7 +55,11 @@ warnings.filterwarnings("ignore", message=".*file_cache.*")
 @click.option(
     "--comprehensive",
     is_flag=True,
-    help="Use comprehensive analysis with multiple sources (10 Jade, 10 AustLII, 10 broader CSE)",
+    help=(
+        "Enable exhaustive analysis by adding broader legal sources (10 additional "
+        "results from a secondary CSE) on top of the standard Jade and AustLII "
+        "searches."
+    ),
 )
 @click.option(
     "--context",
@@ -61,7 +81,10 @@ def lookup(question, mode, extract, comprehensive, context):
               structured analysis, or 'broad' for more creative exploration.
         extract: Extract specific information - 'citations' for case references,
                 'principles' for legal rules, or 'checklist' for practical items.
-        comprehensive: Use comprehensive analysis with multiple sources (10 Jade, 10 AustLII, 10 broader CSE).
+        comprehensive: If True, performs an exhaustive analysis by also querying a
+            secondary "comprehensive" CSE (up to 10 additional results) in
+            addition to the standard Jade and AustLII searches which always run
+            when the relevant CSE IDs are configured.
 
     Raises:
         click.ClickException: If there are errors with the search or LLM API calls.
@@ -76,41 +99,29 @@ def lookup(question, mode, extract, comprehensive, context):
     except Exception as e:
         raise click.ClickException(f"Search initialization error: {e}")
 
+    # Collect links from configured Custom Search Engines
     links = []
-    # Jade CSE search (primary)
-    jade_limit = 10
-    try:
-        res_jade = service.cse().list(q=question, cx=CONFIG.cse_id, num=jade_limit).execute()
-        jade_links = [item.get("link") for item in res_jade.get("items", [])][:jade_limit]
-        links.extend(jade_links)
-    except Exception as e:
-        raise click.ClickException(f"Jade CSE search error: {e}")
-
+    # Primary Jade CSE search
+    links.extend(_perform_cse_search(
+        service, question, CONFIG.cse_id, 10, primary=True
+    ))
     # AustLII CSE search (optional)
-    austlii_id = getattr(CONFIG, "cse_id_austlii", None)
-    if isinstance(austlii_id, str) and austlii_id:
-        aus_limit = 10
-        try:
-            res_aus = service.cse().list(q=question, cx=austlii_id, num=aus_limit).execute()
-            aus_links = [item.get("link") for item in res_aus.get("items", [])][:aus_limit]
-            links.extend(aus_links)
-        except Exception as e:
-            click.echo(f"Warning: AustLII CSE search failed: {e}")
-            logging.exception("AustLII CSE search failed", exc_info=e)
-
-    # Comprehensive CSE search (optional, only for comprehensive mode)
+    links.extend(_perform_cse_search(
+        service, question, getattr(CONFIG, "cse_id_austlii", None), 10
+    ))
+    # Comprehensive CSE search (optional)
     if comprehensive:
-        comp_id = getattr(CONFIG, "cse_id_comprehensive", None)
-        if isinstance(comp_id, str) and comp_id:
-            comp_limit = 10
-            try:
-                res_comp = service.cse().list(q=question, cx=comp_id, num=comp_limit).execute()
-                comp_links = [item.get("link") for item in res_comp.get("items", [])][:comp_limit]
-                links.extend(comp_links)
-            except Exception as e:
-                click.echo(f"Warning: Secondary CSE search failed: {e}")
-                logging.exception("Secondary CSE search failed", exc_info=e)
-
+        links.extend(_perform_cse_search(
+            service, question, getattr(CONFIG, "cse_id_comprehensive", None), 10
+        ))
+    # Remove duplicate links while preserving order
+    seen = set()
+    unique_links = []
+    for link in links:
+        if link and link not in seen:
+            seen.add(link)
+            unique_links.append(link)
+    links = unique_links
     # Display found links
     click.echo("Found links:")
     for link in links:

--- a/litassist/commands/lookup.py
+++ b/litassist/commands/lookup.py
@@ -27,14 +27,16 @@ warnings.filterwarnings("ignore", message=".*file_cache.*")
 
 def _perform_cse_search(service, query, cse_id, limit, primary=False):
     """Perform a Google Custom Search Engine lookup and return a list of links."""
+    from googleapiclient.errors import Error as GoogleApiError
+
     if not cse_id:
         return []
     try:
         res = service.cse().list(q=query, cx=cse_id, num=limit).execute()
         items = res.get("items", [])
         return [item.get("link") for item in items]
-    except Exception as e:
-        msg = f"CSE search failed for '{cse_id}' ({type(e).__name__}): {e}"
+    except GoogleApiError as e:
+        msg = f"CSE search failed for '{cse_id}': {e}"
         if primary:
             raise click.ClickException(msg)
         click.echo(f"Warning: {msg}")

--- a/litassist/commands/lookup.py
+++ b/litassist/commands/lookup.py
@@ -56,9 +56,8 @@ def _perform_cse_search(service, query, cse_id, limit, primary=False):
     "--comprehensive",
     is_flag=True,
     help=(
-        "Enable exhaustive analysis by adding broader legal sources (10 additional "
-        "results from a secondary CSE) on top of the standard Jade and AustLII "
-        "searches."
+        "Enable comprehensive mode: standard searches yield up to 5 results each from Jade and AustLII; "
+        "comprehensive mode yields up to 10 results each from Jade, AustLII, and a secondary CSE."
     ),
 )
 @click.option(
@@ -81,10 +80,9 @@ def lookup(question, mode, extract, comprehensive, context):
               structured analysis, or 'broad' for more creative exploration.
         extract: Extract specific information - 'citations' for case references,
                 'principles' for legal rules, or 'checklist' for practical items.
-        comprehensive: If True, performs an exhaustive analysis by also querying a
-            secondary "comprehensive" CSE (up to 10 additional results) in
-            addition to the standard Jade and AustLII searches which always run
-            when the relevant CSE IDs are configured.
+    comprehensive: If True, switches to comprehensive mode: standard searches yield up to
+        5 results each from Jade and AustLII; comprehensive searches yield up to
+        10 results each from Jade, AustLII, and an additional CSE.
 
     Raises:
         click.ClickException: If there are errors with the search or LLM API calls.
@@ -101,18 +99,23 @@ def lookup(question, mode, extract, comprehensive, context):
 
     # Collect links from configured Custom Search Engines
     links = []
+    # Determine per-source limits
+    if comprehensive:
+        jade_limit = austlii_limit = comp_limit = 10
+    else:
+        jade_limit = austlii_limit = 5
     # Primary Jade CSE search
     links.extend(_perform_cse_search(
-        service, question, CONFIG.cse_id, 10, primary=True
+        service, question, CONFIG.cse_id, jade_limit, primary=True
     ))
     # AustLII CSE search (optional)
     links.extend(_perform_cse_search(
-        service, question, getattr(CONFIG, "cse_id_austlii", None), 10
+        service, question, getattr(CONFIG, "cse_id_austlii", None), austlii_limit
     ))
     # Comprehensive CSE search (optional)
     if comprehensive:
         links.extend(_perform_cse_search(
-            service, question, getattr(CONFIG, "cse_id_comprehensive", None), 10
+            service, question, getattr(CONFIG, "cse_id_comprehensive", None), comp_limit
         ))
     # Remove duplicate and empty links while preserving order
     links = list(dict.fromkeys(filter(None, links)))

--- a/litassist/commands/lookup.py
+++ b/litassist/commands/lookup.py
@@ -34,7 +34,7 @@ def _perform_cse_search(service, query, cse_id, limit, primary=False):
         items = res.get("items", [])
         return [item.get("link") for item in items]
     except Exception as e:
-        msg = f"CSE search failed for '{cse_id}': {e}"
+        msg = f"CSE search failed for '{cse_id}' ({type(e).__name__}): {e}"
         if primary:
             raise click.ClickException(msg)
         click.echo(f"Warning: {msg}")

--- a/litassist/commands/lookup.py
+++ b/litassist/commands/lookup.py
@@ -38,7 +38,7 @@ def _perform_cse_search(service, query, cse_id, limit, primary=False):
         if primary:
             raise click.ClickException(msg)
         click.echo(f"Warning: {msg}")
-        logging.exception(msg, exc_info=e)
+        logging.exception(msg)
         return []
 
 
@@ -114,14 +114,8 @@ def lookup(question, mode, extract, comprehensive, context):
         links.extend(_perform_cse_search(
             service, question, getattr(CONFIG, "cse_id_comprehensive", None), 10
         ))
-    # Remove duplicate links while preserving order
-    seen = set()
-    unique_links = []
-    for link in links:
-        if link and link not in seen:
-            seen.add(link)
-            unique_links.append(link)
-    links = unique_links
+    # Remove duplicate and empty links while preserving order
+    links = list(dict.fromkeys(filter(None, links)))
     # Display found links
     click.echo("Found links:")
     for link in links:

--- a/litassist/config.py
+++ b/litassist/config.py
@@ -140,6 +140,9 @@ class Config:
             self.cse_id_comprehensive = self.cfg["google_cse"].get(
                 "cse_id_comprehensive", None
             )
+            self.cse_id_austlii = self.cfg["google_cse"].get(
+                "cse_id_austlii", None
+            )
             self.pc_key = self.cfg["pinecone"]["api_key"]
             self.pc_env = self.cfg["pinecone"]["environment"]
             self.pc_index = self.cfg["pinecone"]["index_name"]


### PR DESCRIPTION
Add optional AustLII CSE ID to config and README.
Extend --comprehensive mode to query Jade, AustLII and broader CSEs for up to 30 total sources (10 each).