### PR TITLE
fix(llm): restore verification token limits and improve truncated response handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,3 +500,5 @@ When saving Claude-generated files to the project:
 - Always use the most common and generic user agent for web access. Never use a weird one that can be filtered out by scraping protections
 - Never truncate any text received from an API call
 - Never scrape jade.io and any of its subdomains
+- never blame openrouter
+- never blame the llm or connectivity. the problem is ALWAYS in your code or configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,5 +500,5 @@ When saving Claude-generated files to the project:
 - Always use the most common and generic user agent for web access. Never use a weird one that can be filtered out by scraping protections
 - Never truncate any text received from an API call
 - Never scrape jade.io and any of its subdomains
-- never blame openrouter
-- never blame the llm or connectivity. the problem is ALWAYS in your code or configuration
+- Never blame openrouter
+- Never blame the llm or connectivity. The problem is ALWAYS in your code or configuration

--- a/litassist/llm/api_handlers.py
+++ b/litassist/llm/api_handlers.py
@@ -351,14 +351,13 @@ def execute_api_call_with_retry(
                     pass
             return resp
 
-        except Exception as e:
+        except json.JSONDecodeError as e:
             # Catch malformed JSON from truncated responses
             # (server timeout, network interruption, connection closed early)
-            if isinstance(e, json.JSONDecodeError):
-                raise StreamingAPIError(
-                    f"Incomplete API response (truncated JSON): {str(e)}"
-                )
-
+            raise StreamingAPIError(
+                f"Incomplete API response (truncated JSON): {str(e)}"
+            )
+        except Exception as e:
             # Check if it's a 413 or similar non-retryable error
             error_str = str(e)
             if any(
@@ -426,7 +425,7 @@ def execute_api_call_with_retry(
                     click.echo(warning_message(
                         f"Connection issue (attempt {retry_state.attempt_number}/5), retrying..."
                     ))
-                elif "JSONDecode" in str(type(error).__name__) or "Incomplete API response" in error_str or "truncated JSON" in error_str.lower():
+                elif "Incomplete API response" in error_str or "truncated JSON" in error_str.lower():
                     click.echo(warning_message(
                         f"Received incomplete response (attempt {retry_state.attempt_number}/5), retrying..."
                     ))

--- a/litassist/llm/api_handlers.py
+++ b/litassist/llm/api_handlers.py
@@ -76,7 +76,7 @@ def get_openai_client(model_name: str):
     config = get_config()
     base_url = config.or_base
     api_key = config.or_key
-    return OpenAI(api_key=api_key, base_url=base_url)
+    return OpenAI(api_key=api_key, base_url=base_url, timeout=600.0, max_retries=0)
 
 
 def parse_openrouter_error(error_info: Dict[str, Any]) -> Tuple[str, str]:
@@ -352,6 +352,13 @@ def execute_api_call_with_retry(
             return resp
 
         except Exception as e:
+            # Catch malformed JSON from truncated responses
+            # (server timeout, network interruption, connection closed early)
+            if isinstance(e, json.JSONDecodeError):
+                raise StreamingAPIError(
+                    f"Incomplete API response (truncated JSON): {str(e)}"
+                )
+
             # Check if it's a 413 or similar non-retryable error
             error_str = str(e)
             if any(
@@ -418,6 +425,10 @@ def execute_api_call_with_retry(
                 elif "timeout" in error_str.lower() or "connection" in error_str.lower():
                     click.echo(warning_message(
                         f"Connection issue (attempt {retry_state.attempt_number}/5), retrying..."
+                    ))
+                elif "JSONDecode" in str(type(error).__name__) or "Incomplete API response" in error_str or "truncated JSON" in error_str.lower():
+                    click.echo(warning_message(
+                        f"Received incomplete response (attempt {retry_state.attempt_number}/5), retrying..."
                     ))
             except Exception:
                 # If we can't get error details, just show generic retry message

--- a/litassist/llm/model_configs.yaml
+++ b/litassist/llm/model_configs.yaml
@@ -77,14 +77,17 @@ verification:
   model: "openai/gpt-5"
   temperature: 0.2
   top_p: 0.3
-  thinking_effort: "high"
+  thinking_effort: "medium"
+  max_tokens: 16384
   enforce_citations: false
+  disable_tools: true
 
 verification-light:
   model: "anthropic/claude-sonnet-4.5"
   temperature: 0.2
   top_p: 0.2
   thinking_effort: "medium"
+  max_tokens: 8192
   enforce_citations: false
   disable_tools: true
 
@@ -93,7 +96,9 @@ verification-heavy:
   temperature: 0.2
   top_p: 0.3
   thinking_effort: "max"
+  max_tokens: 16384
   enforce_citations: false
+  disable_tools: true
 
 verify-reasoning:
   model: "anthropic/claude-sonnet-4.5"
@@ -110,6 +115,7 @@ verify-soundness:
   thinking_effort: "max"
   verbosity: "high"
   enforce_citations: false
+  disable_tools: true
 
 counselnotes:
   model: "openai/o3-pro"
@@ -159,6 +165,7 @@ cove-answers:
   top_p: 0.3
   thinking_effort: "high"
   enforce_citations: false
+  disable_tools: true
 
 cove-verify:
   model: "anthropic/claude-sonnet-4.5"
@@ -174,3 +181,4 @@ cove-final:
   top_p: 0.4
   thinking_effort: "max"
   enforce_citations: false
+  disable_tools: true


### PR DESCRIPTION
## Summary

- Restore explicit max_tokens to verification configs (removed in v2 refactoring)
- Add handling for truncated JSON responses from API timeouts
- Increase OpenAI client timeout to 600s, disable built-in retries

## Changes

- verification: max_tokens: 16384
- verification-light: max_tokens: 8192  
- verification-heavy: max_tokens: 16384
- Catch JSONDecodeError and raise StreamingAPIError for truncated responses