### PR TITLE
fix(verify): don't record verification as complete on short-circuit (follow-up to #83)

### DIFF
--- a/litassist/commands/draft/core.py
+++ b/litassist/commands/draft/core.py
@@ -209,6 +209,7 @@ def draft(ctx, documents, query, heavy, noverify, output):
     # Verification status, set by the verification block below; only consulted
     # on the not-noverify path (the noverify path reports "Skipped" directly).
     verification_status = "Skipped (--noverify)"
+    short_circuit = None
 
     if not noverify:
         # Save raw pre-verification output for audit trail
@@ -252,7 +253,9 @@ def draft(ctx, documents, query, heavy, noverify, output):
                 "draft",
                 "verification",
                 "end",
-                "Verification complete"
+                f"Verification short-circuited: {short_circuit}"
+                if short_circuit
+                else "Verification complete",
             )
         except Exception:
             pass
@@ -340,7 +343,11 @@ def draft(ctx, documents, query, heavy, noverify, output):
             },
             # Response content removed - already logged by LLMClient separately
             "usage": usage,
-            "verification": "disabled" if noverify else ("heavy" if heavy else "standard"),
+            "verification": (
+                "disabled" if noverify
+                else "short-circuited" if short_circuit
+                else ("heavy" if heavy else "standard")
+            ),
             "output_file": output_file,
         },
     )

--- a/litassist/commands/extractfacts/core.py
+++ b/litassist/commands/extractfacts/core.py
@@ -160,7 +160,9 @@ def extractfacts(file, heavy, noverify, output):
                 "extractfacts",
                 "verification",
                 "end",
-                "Verification complete"
+                f"Verification short-circuited: {short_circuit}"
+                if short_circuit
+                else "Verification complete",
             )
         except Exception:
             pass

--- a/litassist/commands/strategy/core.py
+++ b/litassist/commands/strategy/core.py
@@ -371,7 +371,9 @@ def strategy(case_facts, outcome, strategies, heavy, noverify, output):
                 "strategy",
                 "verification",
                 "end",
-                "Verification complete",
+                f"Verification short-circuited: {short_circuit}"
+                if short_circuit
+                else "Verification complete",
                 {"model": LLMClientFactory.get_model_for_command("verification")},
             )
         except Exception:

--- a/tests/unit/test_draft_command_comprehensive.py
+++ b/tests/unit/test_draft_command_comprehensive.py
@@ -100,6 +100,51 @@ class TestDraftCommand:
         finally:
             Path(facts_file).unlink()
 
+    @patch("litassist.commands.draft.core.detect_factual_hallucinations")
+    @patch("litassist.commands.draft.core.verify_content_if_needed")
+    @patch("litassist.commands.draft.core.LLMClientFactory.for_command")
+    @patch("litassist.commands.draft.core.save_command_output")
+    @patch("litassist.commands.draft.core.save_log")
+    @patch("litassist.commands.draft.prompt_builder.PROMPTS")
+    def test_draft_short_circuit_recorded_not_applied(
+        self,
+        mock_prompts,
+        mock_save_log,
+        mock_save_output,
+        mock_llm_factory,
+        mock_verify,
+        mock_halluc,
+    ):
+        """A verification short-circuit must be recorded in the draft's saved
+        metadata, not reported as standard verification applied."""
+        mock_prompts.get.return_value = "Test template"
+        mock_client = MagicMock()
+        mock_client.complete.return_value = (
+            "DRAFT CONTENT",
+            {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5},
+        )
+        mock_llm_factory.return_value = mock_client
+        mock_save_output.return_value = "outputs/draft_test.txt"
+        # Verification short-circuited before the LLM stage.
+        mock_verify.return_value = ("DRAFT CONTENT", False, "citation pattern issues")
+        mock_halluc.return_value = []
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("Some source document content for drafting.")
+            src = f.name
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                draft, [src, "draft a demand letter"], obj={"premium": False}
+            )
+            assert result.exit_code == 0
+            assert "short-circuited" in result.output.lower()
+            # Final saved metadata records the short-circuit, not "Standard verification".
+            final_meta = mock_save_output.call_args_list[-1].kwargs["metadata"]
+            assert "short-circuited" in final_meta["Verification"].lower()
+        finally:
+            Path(src).unlink()
+
     @patch("litassist.commands.draft.core.LLMClientFactory.for_command")
     @patch("litassist.commands.draft.core.save_command_output")
     @patch("litassist.commands.draft.core.save_log")

--- a/tests/unit/test_strategy_command_comprehensive.py
+++ b/tests/unit/test_strategy_command_comprehensive.py
@@ -278,6 +278,62 @@ class TestStrategyGeneration:
             Path(facts_file).unlink()
 
     @patch("litassist.commands.strategy.core.LLMClientFactory.for_command")
+    @patch("litassist.commands.strategy.file_handler.save_command_output")
+    @patch("litassist.commands.strategy.file_handler.save_log")
+    @patch("litassist.commands.strategy.core.verify_content_if_needed")
+    @patch("litassist.commands.strategy.core.PROMPTS")
+    def test_strategy_short_circuit_recorded_not_complete(
+        self,
+        mock_prompts,
+        mock_verify,
+        mock_save_log,
+        mock_save_output,
+        mock_llm_factory,
+    ):
+        """A verification short-circuit must be recorded in the saved metadata,
+        not reported as completed verification."""
+        mock_prompts.get.return_value = "Test prompt"
+        # Verification short-circuited before the LLM stage.
+        mock_verify.return_value = ("Strategy content", False, "citation pattern issues")
+        mock_client = MagicMock()
+        mock_client.complete.return_value = (
+            "## OPTION 1: Something\nDetail...",
+            {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5},
+        )
+        mock_client.validate_citations.return_value = []
+        mock_llm_factory.return_value = mock_client
+        mock_save_output.return_value = "outputs/strategy_test.txt"
+
+        facts = "\n".join(
+            f"{h}: x"
+            for h in [
+                "Parties", "Background", "Key Events", "Legal Issues",
+                "Evidence Available", "Opposing Arguments", "Procedural History",
+                "Jurisdiction", "Applicable Law", "Client Objectives",
+            ]
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(facts)
+            facts_file = f.name
+        try:
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                result = runner.invoke(
+                    strategy, [facts_file, "--outcome", "Win"], obj={"premium": False}
+                )
+            assert result.exit_code == 0
+            assert "short-circuited" in result.output.lower()
+            # The saved strategy metadata records the short-circuit, not "Standard verification".
+            verifications = [
+                call.kwargs["metadata"]["Verification"]
+                for call in mock_save_output.call_args_list
+                if call.kwargs.get("metadata", {}).get("Verification")
+            ]
+            assert any("short-circuited" in v.lower() for v in verifications), verifications
+        finally:
+            Path(facts_file).unlink()
+
+    @patch("litassist.commands.strategy.core.LLMClientFactory.for_command")
     def test_strategy_generation_invalid_facts(self, mock_llm_factory):
         """Test strategy generation with invalid case facts."""
         # Create invalid case facts file (missing required headings)


### PR DESCRIPTION
## Summary

Follow-up to #83 (merged). Codex's stop-time review flagged that the verification **audit trail** still recorded completion on a short-circuit, even though #83 fixed the console message and saved metadata.

On a verification short-circuit (chain bails before the LLM stage on citation-pattern / database issues), the verification stage's `"end"` task-event still logged **"Verification complete"** — which `log_task_event` persists via `save_log` and echoes — and `draft`'s audit `save_log` recorded `verification: "standard"/"heavy"`. So the audit record claimed verification ran when it did not.

## Changes

- `extractfacts`, `strategy`, `draft`: the verification stage-end task-event now logs `"Verification short-circuited: <reason>"` on the short-circuit path instead of `"Verification complete"`.
- `draft`: the audit `save_log` `verification` field now records `"short-circuited"` on that path (instead of `heavy`/`standard`).
- Added regression tests: `test_strategy_short_circuit_recorded_not_complete` and `test_draft_short_circuit_recorded_not_applied` assert the short-circuit reaches the **saved metadata**, not just the console echo (the test gap Codex noted).

## Verification

`ruff check litassist tests` clean; full unit suite **532 passed** (pre-commit hook gate).
