### PR TITLE
fix(logging): fall back when the log directory exists but is read-only

### DIFF
--- a/litassist/logging/config.py
+++ b/litassist/logging/config.py
@@ -30,18 +30,25 @@ def setup_logging(verbose: bool = False, log_dir: str = None) -> str:
             os.path.dirname(os.path.dirname(__file__)), "..", "logs"
         )
 
-    # Resolve a writable log directory. If the primary location is read-only
-    # (e.g. a system-wide install with no LITASSIST_LOG_DIR set), fall back to the
-    # caller's cwd and then the system temp dir so the CLI never crashes on
-    # startup merely because it cannot create its default log directory.
+    # Resolve a writable log file. makedirs(exist_ok=True) succeeds for an existing
+    # but read-only directory, so creating the dir is not enough - we open the
+    # target file (exactly what the FileHandler does) to confirm it is writable.
+    # If the primary location is read-only (e.g. a system-wide install with no
+    # LITASSIST_LOG_DIR set), fall back to the caller's cwd and then the system
+    # temp dir so the CLI never crashes on startup over its log location.
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
     primary = log_dir
+    log_file = None
     for candidate in (
         primary,
         os.path.join(os.getcwd(), "logs"),
         os.path.join(tempfile.gettempdir(), "litassist-logs"),
     ):
+        candidate_file = os.path.join(candidate, f"litassist_{timestamp}.log")
         try:
             os.makedirs(candidate, exist_ok=True)
+            # Append-open confirms write access without truncating an existing log.
+            open(candidate_file, "a", encoding="utf-8").close()
         except OSError:
             continue
         if candidate != primary:
@@ -50,16 +57,13 @@ def setup_logging(verbose: bool = False, log_dir: str = None) -> str:
                 primary,
                 candidate,
             )
-        log_dir = candidate
+        log_file = candidate_file
         break
     else:
         # Nothing (not even the temp dir) was writable - re-raise on the primary
         # so the failure is loud rather than silently producing a bad path.
         os.makedirs(primary, exist_ok=True)
-
-    # Create timestamped log file
-    timestamp = time.strftime("%Y%m%d_%H%M%S")
-    log_file = os.path.join(log_dir, f"litassist_{timestamp}.log")
+        log_file = os.path.join(primary, f"litassist_{timestamp}.log")
 
     # Clear any existing handlers
     root_logger = logging.getLogger()

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -70,3 +70,29 @@ def test_setup_logging_falls_back_when_log_dir_unwritable(
 
     assert os.path.isdir(os.path.dirname(log_file))
     assert os.path.realpath(str(primary)) != os.path.realpath(os.path.dirname(log_file))
+
+
+def test_setup_logging_falls_back_when_existing_dir_readonly(
+    monkeypatch, tmp_path, restore_root_logging
+):
+    """An existing read-only log dir passes makedirs(exist_ok=True) but fails when
+    the file handler opens. setup_logging must detect this (by opening the target
+    file) and fall back, not crash.
+    """
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root bypasses directory write permissions")
+
+    primary = tmp_path / "existing_ro_logs"
+    primary.mkdir()  # already exists...
+    os.chmod(primary, 0o555)  # ...but is read-only, so makedirs is a no-op success
+    monkeypatch.setenv("LITASSIST_LOG_DIR", str(primary))
+    monkeypatch.chdir(tmp_path)  # writable cwd/logs fallback
+
+    try:
+        log_file = setup_logging(verbose=False)  # must not raise
+        assert os.path.exists(log_file)
+        assert os.path.realpath(str(primary)) != os.path.realpath(
+            os.path.dirname(log_file)
+        )
+    finally:
+        os.chmod(primary, 0o755)  # restore so tmp_path cleanup can remove it


### PR DESCRIPTION
## Summary

Follow-up to #88. The read-only fallback added there only guarded directory *creation*, but `os.makedirs(exist_ok=True)` is a no-op success on an existing read-only directory — so the CLI still crashed when `logging.FileHandler` opened the log file. Caught by a Codex stop-time review.

The fallback loop now opens the target log file in append mode to confirm write access before selecting a candidate, covering both:
- the directory cannot be created (the original case), and
- the directory exists but is read-only (this fix).

It still falls back `primary -> cwd/logs -> tempdir`, warns once on fallback, and re-raises only if nothing is writable.

## Test plan
- New regression test `test_setup_logging_falls_back_when_existing_dir_readonly` (creates a `chmod 0o555` dir; skipped under root where permissions are bypassed). Confirmed it fails on the pre-fix code (PermissionError from `FileHandler`) and passes after.
- `pytest tests/unit` -> 534 passed
- `ruff check` clean
- repo `logs/` delta over the suite = 0