### PR TITLE
C2 option 1: resolve authorised-report cites via parallel medium-neutral cite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated: 17/06/2026
+Last updated: 22/06/2026
 
 All notable changes to LitAssist will be documented in this file.
 
@@ -12,6 +12,20 @@ Historical dated sections preserve the model names that were current when those 
 ## [Unreleased]
 
 ### Added
+- Authorised-report citation retrieval (C2 option 1). `fetch_citation_context` now
+  takes an optional `source_text`; when an authorised-report cite like
+  `(1999) 201 CLR 1` has no constructible AustLII URL, `resolve_neutral_from_parallel`
+  (`litassist/citation/austlii.py`) recovers a medium-neutral cite printed parallel to
+  it in the document (e.g. `[1999] HCA 66`) and uses the existing direct-AustLII
+  fallback, so `verify --soundness`/`--reasoning` and CoVe stop running context-starved
+  on those cites. Resolution is gated by a +/-1-year proximity check and, after fetch,
+  a parallelism guard that requires the page to carry the traditional cite's bare
+  report form - so an unrelated same-year neutral cite (including a non-Australian
+  traditional cite) cannot false-fetch the wrong judgment. Verified end-to-end against
+  the live Mann v Carnell page. The four callers (CoVe + the three `verify` handlers)
+  pass the original document; behaviour is unchanged when `source_text` is omitted.
+  Option 2 (LawCite citator, for CLR-only sources with no parallel cite) stays
+  deferred. ROADMAP Phase 2 / TODO C2.
 - Actual per-call cost from OpenRouter. Every LLM request now sets
   `usage: {include: true}`, so the response carries OpenRouter's real billed `cost`
   and a generation `id`; both are captured in `response_parser` and summed across

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ Historical dated sections preserve the model names that were current when those 
   (`litassist/citation/austlii.py`) recovers a medium-neutral cite printed parallel to
   it in the document (e.g. `[1999] HCA 66`) and uses the existing direct-AustLII
   fallback, so `verify --soundness`/`--reasoning` and CoVe stop running context-starved
-  on those cites. Resolution is gated by a +/-1-year proximity check and, after fetch,
-  a parallelism guard that requires the page to carry the traditional cite's bare
-  report form - so an unrelated same-year neutral cite (including a non-Australian
-  traditional cite) cannot false-fetch the wrong judgment. Verified end-to-end against
-  the live Mann v Carnell page. The four callers (CoVe + the three `verify` handlers)
+  on those cites. The resolver returns the nearest co-occurring neutral cite; the
+  fetched page is then accepted only if it lists the traditional cite's bare report
+  form in its own parallel-citation group, so a wrong-case, non-Australian, or
+  abbreviation-collision pairing cannot false-fetch the wrong judgment. Verified
+  end-to-end against the live Mann v Carnell page. The four callers (CoVe + the three `verify` handlers)
   pass the original document; behaviour is unchanged when `source_text` is omitted.
   Option 2 (LawCite citator, for CLR-only sources with no parallel cite) stays
   deferred. ROADMAP Phase 2 / TODO C2.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # LitAssist Feature Roadmap
 
-Last updated: 17/06/2026
+Last updated: 21/06/2026
 **Status:** Strategic planning; roadmap items are aspirational unless marked DONE, PARTIALLY SUPERSEDED, or already implemented elsewhere
 **Confidence:** 0.88
 
@@ -282,6 +282,16 @@ for those classes today. P-JUDGE must **surface and cap** on this (see its updat
 spec) rather than let a judge launder un-fetchable citations into a green score;
 otherwise ensemble verification polishes the output end of a pipe starved at the
 input.
+
+**First retrieval-gap closure shipped (C2 option 1, 21/06/2026):** the
+authorised-report class is now partly addressed. `resolve_neutral_from_parallel`
+(`litassist/citation/austlii.py`) recovers a medium-neutral cite printed parallel to
+the traditional cite in the source document (e.g. `(1999) 201 CLR 1; [1999] HCA 66`)
+and feeds the existing direct-AustLII fallback via a new optional `source_text` arg
+to `fetch_citation_context`. This closes the gap for real drafts that co-occur both
+cite forms; a deliberately CLR-only source (including the P-JUDGE `authorised_report`
+fixture) still needs option 2 (AustLII LawCite citator, deferred/gated) or Jade
+cookie-reuse. Jade.io and AustLII-PDF classes remain open. See TODO.md C1/C2.
 
 **Theme - ensemble divergence / uncertainty:** P1-12 and P2-19 together
 establish the principle that where independent models disagree, confidence is

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # LitAssist Development TODO
 
-Last updated: 17/06/2026
+Last updated: 21/06/2026
 
 **Note:** Strategic feature planning (litigation support, advisory capabilities, new commands) is now in [ROADMAP.md](ROADMAP.md). This file focuses on bugs, technical debt, and code quality improvements.
 
@@ -55,30 +55,42 @@ reason reads "Document fetch or content validation failed" instead of "URL not
 found - CSE returned no results"). Making these citations actually retrievable is
 deferred:
 - **C1 (retrieval) - downgraded, not a standalone fix.** Landing on the AustLII
-  case page (whose header carries parallel cites for `_check_header_parallel_citations`
-  to validate) is impossible from a CLR-only cite: `construct_austlii_url`
-  (`litassist/citation/austlii.py:28`) requires medium-neutral `[YYYY] COURT N`,
+  case page is impossible from a CLR-only cite: `construct_austlii_url`
+  (`litassist/citation/austlii.py`) requires medium-neutral `[YYYY] COURT N`,
   and `normalize_citation` leaves the CLR string unchanged, so the CSE query has
-  no name/neutral cite to hit.
-- **C2 (the real lever) - add a `traditional cite -> medium-neutral cite`
-  primitive.** Source the neutral cite from, cheapest first: (1) draft
-  co-occurrence (drafts usually print both forms together, e.g.
-  `... (1999) 201 CLR 1; [1999] HCA 66`) - free, no fetch, prefer this; or
-  (2) AustLII LawCite citator via a constructible query URL
-  (`https://www.austlii.edu.au/cgi-bin/LawCite?cit=...`) - one extra fetch plus a
-  new HTML parser (AustLII is permitted; only jade.io is off-limits). Once the
-  neutral cite is known, the existing AustLII fetch + parallel-citation validation
-  already work. Decide C2 option 1 vs 2 deliberately before building.
+  no name/neutral cite to hit. (Correction, 21/06/2026: once the page IS fetched,
+  validation passes via the `exact_primary_location` strategy - the verbatim CLR
+  string in the page body - NOT `_check_header_parallel_citations`, whose regex
+  matches only neutral `[YYYY] COURT N` forms and returns False for every CLR/ALR
+  cite. See `tests/unit/test_citation_context_parallel_resolution.py`.)
+- **C2 (the real lever) - `traditional cite -> medium-neutral cite` primitive.**
+  - **Option 1 - draft co-occurrence: SHIPPED 21/06/2026.**
+    `resolve_neutral_from_parallel` (`litassist/citation/austlii.py`) recovers a
+    medium-neutral cite printed parallel to the traditional cite in the source
+    document (e.g. `... (1999) 201 CLR 1; [1999] HCA 66`); `fetch_citation_context`
+    takes an optional `source_text` and uses it in the direct-AustLII fallback, so
+    the existing fetch + `exact_primary_location` validation run. Free, no fetch.
+    The four real callers (CoVe + the three `verify` handlers) pass the original
+    document. Branch `feat/c2-parallel-cite-resolver`.
+  - **Limitation:** option 1 only fires when the neutral cite is present in the
+    source. It does NOT resolve a deliberately CLR-only document - including the
+    P-JUDGE `authorised_report` benchmark fixture, which stays capped.
+  - **Option 2 - AustLII LawCite citator [DEFERRED, gated].** Build only if option 1
+    coverage proves insufficient in production. Query
+    `https://www.austlii.edu.au/cgi-bin/LawCite?cit=...` (one extra fetch + a new
+    HTML parser; AustLII permitted, jade.io off-limits) to resolve a neutral cite
+    when the source has none. This is the path that would flip the CLR-only fixture.
 
-**Now measured (09/06/2026):** this gap - plus the jade.io cookie-reuse [SOON]
-item and the AustLII PDF block above - is the **binding constraint** for the
-trustworthy-output thrust: better verification cannot help citations the pipeline
-cannot fetch. The P-JUDGE eval benchmark deliberately tags these classes
-`fetchable:false` and **caps `citation_grounding`** on un-fetchable cites, so the
-gap is a quantified line item (`=== RETRIEVAL GAP ===` in the report) rather than
-an invisible assumption. Closing C2 (and Jade cookie-reuse) flips the tags to
-`fetchable:true` and lifts the eval's score ceiling - which is how the win becomes
-visible. See ROADMAP P-JUDGE.
+**Now measured (09/06/2026; updated 21/06/2026):** this gap - plus the jade.io
+cookie-reuse [SOON] item and the AustLII PDF block above - is the **binding
+constraint** for the trustworthy-output thrust: better verification cannot help
+citations the pipeline cannot fetch. The P-JUDGE eval benchmark deliberately tags
+these classes `fetchable:false` and **caps `citation_grounding`** on un-fetchable
+cites, so the gap is a quantified line item (`=== RETRIEVAL GAP ===` in the report)
+rather than an invisible assumption. C2 option 1 closes the gap for real drafts that
+co-occur both cite forms (visible in production fetch-success logs); the synthetic
+`authorised_report` fixture stays `fetchable:false` until option 2 or Jade
+cookie-reuse lands. See ROADMAP P-JUDGE.
 
 ## Next Steps
 1. Review and prioritize remaining TODO items for next sprint

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # LitAssist Development TODO
 
-Last updated: 21/06/2026
+Last updated: 22/06/2026
 
 **Note:** Strategic feature planning (litigation support, advisory capabilities, new commands) is now in [ROADMAP.md](ROADMAP.md). This file focuses on bugs, technical debt, and code quality improvements.
 
@@ -58,20 +58,25 @@ deferred:
   case page is impossible from a CLR-only cite: `construct_austlii_url`
   (`litassist/citation/austlii.py`) requires medium-neutral `[YYYY] COURT N`,
   and `normalize_citation` leaves the CLR string unchanged, so the CSE query has
-  no name/neutral cite to hit. (Correction, 21/06/2026: once the page IS fetched,
-  validation passes via the `exact_primary_location` strategy - the verbatim CLR
-  string in the page body - NOT `_check_header_parallel_citations`, whose regex
-  matches only neutral `[YYYY] COURT N` forms and returns False for every CLR/ALR
-  cite. See `tests/unit/test_citation_context_parallel_resolution.py`.)
+  no name/neutral cite to hit. (Correction, 22/06/2026, from a live AustLII fetch:
+  the fetched HCA page prints the report cite BARE - "Mann v Carnell [1999] HCA 66;
+  201 CLR 1; 168 ALR 86" - so the parenthesised "(1999) 201 CLR 1" never appears
+  verbatim and does NOT validate via `exact_primary_location`;
+  `_check_header_parallel_citations` also returns False for CLR/ALR forms. So a
+  C2-resolved fetch validates the page against the resolved NEUTRAL cite
+  "[1999] HCA 66" - verbatim on its own page - then maps the document to the original
+  citation key. See `tests/unit/test_citation_context_parallel_resolution.py`.)
 - **C2 (the real lever) - `traditional cite -> medium-neutral cite` primitive.**
   - **Option 1 - draft co-occurrence: SHIPPED 21/06/2026.**
     `resolve_neutral_from_parallel` (`litassist/citation/austlii.py`) recovers a
     medium-neutral cite printed parallel to the traditional cite in the source
     document (e.g. `... (1999) 201 CLR 1; [1999] HCA 66`); `fetch_citation_context`
-    takes an optional `source_text` and uses it in the direct-AustLII fallback, so
-    the existing fetch + `exact_primary_location` validation run. Free, no fetch.
-    The four real callers (CoVe + the three `verify` handlers) pass the original
-    document. Branch `feat/c2-parallel-cite-resolver`.
+    takes an optional `source_text` and uses it in the direct-AustLII fallback,
+    validating the fetched page against the resolved neutral cite (see C1). Free, no
+    extra fetch. The four real callers (CoVe + the three `verify` handlers) pass the
+    original document. Verified end-to-end against the live Mann v Carnell page
+    (22/06/2026): `(1999) 201 CLR 1` resolved, fetched and mapped (122903 chars);
+    control without source_text still fails. Branch `feat/c2-parallel-cite-resolver`.
   - **Limitation:** option 1 only fires when the neutral cite is present in the
     source. It does NOT resolve a deliberately CLR-only document - including the
     P-JUDGE `authorised_report` benchmark fixture, which stays capped.

--- a/TODO.md
+++ b/TODO.md
@@ -77,15 +77,16 @@ deferred:
     original document. Verified end-to-end against the live Mann v Carnell page
     (22/06/2026): `(1999) 201 CLR 1` resolved, fetched and mapped (122903 chars);
     control without source_text still fails. Branch `feat/c2-parallel-cite-resolver`.
-    A C2-resolved fetch is accepted only if the fetched page also carries the
-    traditional cite's bare report form in its header (e.g. `201 CLR 1`), so an
-    unrelated same-year neutral cite in the window - in particular a non-Australian
-    traditional cite like `[2017] AC 467` - cannot false-fetch an Australian judgment.
+    The resolver is a plain nearest-neighbour finder (no jurisdiction or year
+    filtering of its own); correctness comes from ONE downstream check - a C2-resolved
+    fetch is accepted only if the fetched page lists the traditional cite's bare report
+    form (e.g. `201 CLR 1`) in its OWN parallel-citation group (between the neutral cite
+    and the judgment date in the header). That single page-truth check rejects a
+    wrong-case fetch, a non-Australian cite (`[2017] AC 467`), and abbreviation
+    collisions (`IR` = AU Industrial Reports vs Irish Reports) jurisdiction-agnostically.
   - **Limitation:** option 1 only fires when the neutral cite is present in the
     source. It does NOT resolve a deliberately CLR-only document - including the
-    P-JUDGE `authorised_report` benchmark fixture, which stays capped. Residual: the
-    parallelism guard matches the report form in the first 2000 chars, so a very short
-    token could in principle match an unrelated page's catchwords (low probability).
+    P-JUDGE `authorised_report` benchmark fixture, which stays capped.
   - **Option 2 - AustLII LawCite citator [DEFERRED, gated].** Build only if option 1
     coverage proves insufficient in production. Query
     `https://www.austlii.edu.au/cgi-bin/LawCite?cit=...` (one extra fetch + a new

--- a/TODO.md
+++ b/TODO.md
@@ -77,9 +77,15 @@ deferred:
     original document. Verified end-to-end against the live Mann v Carnell page
     (22/06/2026): `(1999) 201 CLR 1` resolved, fetched and mapped (122903 chars);
     control without source_text still fails. Branch `feat/c2-parallel-cite-resolver`.
+    A C2-resolved fetch is accepted only if the fetched page also carries the
+    traditional cite's bare report form in its header (e.g. `201 CLR 1`), so an
+    unrelated same-year neutral cite in the window - in particular a non-Australian
+    traditional cite like `[2017] AC 467` - cannot false-fetch an Australian judgment.
   - **Limitation:** option 1 only fires when the neutral cite is present in the
     source. It does NOT resolve a deliberately CLR-only document - including the
-    P-JUDGE `authorised_report` benchmark fixture, which stays capped.
+    P-JUDGE `authorised_report` benchmark fixture, which stays capped. Residual: the
+    parallelism guard matches the report form in the first 2000 chars, so a very short
+    token could in principle match an unrelated page's catchwords (low probability).
   - **Option 2 - AustLII LawCite citator [DEFERRED, gated].** Build only if option 1
     coverage proves insufficient in production. Query
     `https://www.austlii.edu.au/cgi-bin/LawCite?cit=...` (one extra fetch + a new

--- a/docs/development/JUDGE_EVAL.md
+++ b/docs/development/JUDGE_EVAL.md
@@ -1,6 +1,6 @@
 # P-JUDGE offline eval harness
 
-Last updated: 17/06/2026
+Last updated: 21/06/2026
 
 Repeatable, real-API quality scoring of litassist outputs against a rubric,
 so prompt/model changes are measured rather than guessed. This is ROADMAP
@@ -69,7 +69,10 @@ expected_citations:
 ```
 
 `retrieval_class` values: `fetchable`, `authorised_report` (no
-medium-neutral cite, so no AustLII URL is constructible - see TODO C1/C2),
+medium-neutral cite, so no AustLII URL is constructible - see TODO C1/C2;
+C2 option 1 (shipped 21/06/2026) resolves these ONLY when the source
+document co-occurs the neutral form, which these deliberately CLR-only
+fixtures do not, so they stay `fetchable: false` until option 2/Jade),
 `jade_spa` (Jade.io is SPA/auth-gated and skipped by the fetcher),
 `austlii_pdf_blocked` (Cloudflare-blocked PDF paths), `not_found` (the
 citation does not correspond to a retrievable real authority, e.g. a

--- a/litassist/citation/austlii.py
+++ b/litassist/citation/austlii.py
@@ -61,20 +61,6 @@ def construct_austlii_url(citation: str) -> str:
 # staying short enough to avoid pairing across unrelated sentences.
 _PARALLEL_CITE_WINDOW = 300
 
-# Max difference between the traditional cite's report year and a candidate neutral
-# cite's year for them to be treated as the SAME case. Parallel cites name one
-# judgment, so the years match or differ by at most one (a late-year judgment reported
-# the next year). A wider gap means a different case sitting nearby in the window
-# (e.g. "(2001) 207 CLR 1; [2005] HCA 5" - the neutral belongs to a 2005 case), so
-# rejecting it prevents a false pairing that character distance alone cannot catch.
-_PARALLEL_CITE_YEAR_TOLERANCE = 1
-
-
-def _citation_year(citation: str):
-    """Year from the leading (YYYY)/[YYYY] of a cite, or None if it carries no year."""
-    match = re.search(r"\d{4}", citation)
-    return int(match.group(0)) if match else None
-
 
 def resolve_neutral_from_parallel(traditional_cite: str, source_text: str) -> str:
     """
@@ -86,27 +72,28 @@ def resolve_neutral_from_parallel(traditional_cite: str, source_text: str) -> st
     the traditional one in source_text we can recover it and let the existing
     AustLII fetch path run.
 
+    This returns the NEAREST AustLII-constructible neutral cite to the traditional cite
+    - parallel cites are written adjacently. Whether that cite is genuinely the same
+    case is confirmed downstream by the caller, which validates the fetched page lists
+    the traditional cite among its own parallel citations; this function does no
+    jurisdiction or year filtering of its own.
+
     Args:
         traditional_cite: the already-extracted cite string (case name / pinpoint
             stripped by extract_citations), e.g. "(1999) 201 CLR 1"
         source_text: the raw document the cite came from (case names intact)
 
     Returns:
-        The best-matching AustLII-constructible neutral cite within the pairing window
-        on either side of the traditional cite, or "" if none. Candidates are validated
-        through construct_austlii_url (excludes the traditional cite itself - round
-        brackets do not match the neutral pattern - and non-AustLII courts). A candidate
-        whose year is more than _PARALLEL_CITE_YEAR_TOLERANCE from the traditional cite's
-        year is rejected as a different case; remaining candidates are ranked by year
-        proximity first, then character distance.
+        The nearest AustLII-constructible neutral cite within the pairing window on
+        either side of the traditional cite, or "" if none. construct_austlii_url
+        filters out the traditional cite itself (round brackets do not match the neutral
+        pattern) and non-AustLII courts.
     """
     if not traditional_cite or not source_text:
         return ""
 
-    traditional_year = _citation_year(traditional_cite)
-
     best = ""
-    best_key = None  # (year_difference, character_distance) - lower is better
+    best_distance = None
     search_from = 0
     while True:
         occ = source_text.find(traditional_cite, search_from)
@@ -121,22 +108,18 @@ def resolve_neutral_from_parallel(traditional_cite: str, source_text: str) -> st
             candidate = m.group(0)
             if not construct_austlii_url(candidate):
                 continue
-            year_difference = 0
-            if traditional_year is not None:
-                year_difference = abs(int(m.group(1)) - traditional_year)
-                if year_difference > _PARALLEL_CITE_YEAR_TOLERANCE:
-                    # Different case sitting in the window - not a parallel cite.
-                    continue
             candidate_pos = window_start + m.start()
-            # Distance from the nearest edge of the traditional occurrence.
-            distance = (
-                occ - candidate_pos
-                if candidate_pos < occ
-                else candidate_pos - occ_end
-            )
-            key = (year_difference, distance)
-            if best_key is None or key < best_key:
-                best_key = key
+            candidate_end = candidate_pos + len(candidate)
+            # Gap between the NEAREST edges of the two cites (symmetric: a left-side
+            # candidate is not penalised by its own length).
+            if candidate_end <= occ:
+                distance = occ - candidate_end
+            elif candidate_pos >= occ_end:
+                distance = candidate_pos - occ_end
+            else:
+                distance = 0
+            if best_distance is None or distance < best_distance:
+                best_distance = distance
                 best = candidate
 
         search_from = occ_end

--- a/litassist/citation/austlii.py
+++ b/litassist/citation/austlii.py
@@ -13,6 +13,12 @@ from typing import Tuple
 from litassist.logging import save_log
 from .constants import COURT_MAPPINGS
 
+# Single source of truth for the medium-neutral cite shape "[YYYY] COURT N".
+# re.search (not match) so it also finds the neutral cite inside a longer string
+# (named cite, or a parallel-citation group); reused by both construct_austlii_url
+# and resolve_neutral_from_parallel so the two never drift.
+_NEUTRAL_CITE_RE = re.compile(r"\[(\d{4})\]\s+([A-Z]+[A-Za-z]*)\s+(\d+)")
+
 
 def construct_austlii_url(citation: str) -> str:
     """
@@ -32,7 +38,7 @@ def construct_austlii_url(citation: str) -> str:
     # Parse medium neutral citation format [YYYY] COURT NUMBER; re.search,
     # not re.match - an anchored match silently failed for every citation
     # prefixed with its case name (P-JUDGE finding, 11/06/2026)
-    match = re.search(r"\[(\d{4})\]\s+([A-Z]+[A-Za-z]*)\s+(\d+)", citation)
+    match = _NEUTRAL_CITE_RE.search(citation)
     if not match:
         return ""
 
@@ -47,6 +53,95 @@ def construct_austlii_url(citation: str) -> str:
 
     # Build AustLII URL
     return f"https://www.austlii.edu.au/cgi-bin/viewdoc/au/cases/{court_path}/{year}/{number}.html"
+
+
+# Max characters between a traditional cite and its parallel medium-neutral cite for
+# the two to count as the same pairing. ~300 spans a typical
+# "(1999) 201 CLR 1; [1999] HCA 66" pair plus an intervening clause/pinpoint, while
+# staying short enough to avoid pairing across unrelated sentences.
+_PARALLEL_CITE_WINDOW = 300
+
+# Max difference between the traditional cite's report year and a candidate neutral
+# cite's year for them to be treated as the SAME case. Parallel cites name one
+# judgment, so the years match or differ by at most one (a late-year judgment reported
+# the next year). A wider gap means a different case sitting nearby in the window
+# (e.g. "(2001) 207 CLR 1; [2005] HCA 5" - the neutral belongs to a 2005 case), so
+# rejecting it prevents a false pairing that character distance alone cannot catch.
+_PARALLEL_CITE_YEAR_TOLERANCE = 1
+
+
+def _citation_year(citation: str):
+    """Year from the leading (YYYY)/[YYYY] of a cite, or None if it carries no year."""
+    match = re.search(r"\d{4}", citation)
+    return int(match.group(0)) if match else None
+
+
+def resolve_neutral_from_parallel(traditional_cite: str, source_text: str) -> str:
+    """
+    Recover a medium-neutral cite printed parallel to a traditional cite (C2 opt 1).
+
+    Authorised-report cites like "(1999) 201 CLR 1" carry no "[YYYY] COURT N" form for
+    construct_austlii_url to build from. Drafts and judgments usually print both forms
+    together ("(1999) 201 CLR 1; [1999] HCA 66"), so when that neutral cite sits near
+    the traditional one in source_text we can recover it and let the existing
+    AustLII fetch path run.
+
+    Args:
+        traditional_cite: the already-extracted cite string (case name / pinpoint
+            stripped by extract_citations), e.g. "(1999) 201 CLR 1"
+        source_text: the raw document the cite came from (case names intact)
+
+    Returns:
+        The best-matching AustLII-constructible neutral cite within the pairing window
+        on either side of the traditional cite, or "" if none. Candidates are validated
+        through construct_austlii_url (excludes the traditional cite itself - round
+        brackets do not match the neutral pattern - and non-AustLII courts). A candidate
+        whose year is more than _PARALLEL_CITE_YEAR_TOLERANCE from the traditional cite's
+        year is rejected as a different case; remaining candidates are ranked by year
+        proximity first, then character distance.
+    """
+    if not traditional_cite or not source_text:
+        return ""
+
+    traditional_year = _citation_year(traditional_cite)
+
+    best = ""
+    best_key = None  # (year_difference, character_distance) - lower is better
+    search_from = 0
+    while True:
+        occ = source_text.find(traditional_cite, search_from)
+        if occ == -1:
+            break
+        occ_end = occ + len(traditional_cite)
+        window_start = max(0, occ - _PARALLEL_CITE_WINDOW)
+        window_end = min(len(source_text), occ_end + _PARALLEL_CITE_WINDOW)
+        window = source_text[window_start:window_end]
+
+        for m in _NEUTRAL_CITE_RE.finditer(window):
+            candidate = m.group(0)
+            if not construct_austlii_url(candidate):
+                continue
+            year_difference = 0
+            if traditional_year is not None:
+                year_difference = abs(int(m.group(1)) - traditional_year)
+                if year_difference > _PARALLEL_CITE_YEAR_TOLERANCE:
+                    # Different case sitting in the window - not a parallel cite.
+                    continue
+            candidate_pos = window_start + m.start()
+            # Distance from the nearest edge of the traditional occurrence.
+            distance = (
+                occ - candidate_pos
+                if candidate_pos < occ
+                else candidate_pos - occ_end
+            )
+            key = (year_difference, distance)
+            if best_key is None or key < best_key:
+                best_key = key
+                best = candidate
+
+        search_from = occ_end
+
+    return best
 
 
 def verify_via_austlii_direct(citation: str, timeout: int = 5) -> Tuple[bool, str, str]:

--- a/litassist/citation_context.py
+++ b/litassist/citation_context.py
@@ -552,7 +552,14 @@ def fetch_citation_context(
                     tail = head[neutral_pos:neutral_pos + 250] if neutral_pos != -1 else ""
                     date_marker = re.search(r"\(\s*\d{1,2}\s+[a-z]+\s+\d{4}\s*\)", tail)
                     parallel_group = tail[: date_marker.start()] if date_marker else tail
-                    if not (report_form_norm and report_form_norm in parallel_group):
+                    # Match the report form as a whole token, not a raw substring: the
+                    # volume and page are digits, so "20 CLR 1" must not match inside
+                    # "120 CLR 1" or "20 CLR 11" (a different cite). Digit boundaries on
+                    # each end prevent that concatenation.
+                    report_found = bool(report_form_norm) and re.search(
+                        r"(?<!\d)" + re.escape(report_form_norm) + r"(?!\d)", parallel_group
+                    )
+                    if not report_found:
                         save_log(
                             "citation_parallel_report_form_absent",
                             {

--- a/litassist/citation_context.py
+++ b/litassist/citation_context.py
@@ -526,6 +526,25 @@ def fetch_citation_context(
             if austlii_url:
                 click.echo("  -> Trying direct AustLII URL")
                 content = _try_fetch_and_validate(austlii_url, validate_cite)
+                if content and validate_cite != citation:
+                    # C2-resolved: confirm the fetched page is genuinely a PARALLEL of
+                    # the traditional cite by checking its bare report form appears
+                    # (AustLII prints "[1999] HCA 66; 201 CLR 1", so strip the leading
+                    # year to get "201 CLR 1"). Guards against pairing a same-year but
+                    # unrelated neutral cite - in particular a non-Australian cite (UK
+                    # "[2017] AC 467") must never resolve to an Australian judgment.
+                    report_form = re.sub(r"^[\(\[]\d{4}[\)\]]\s*", "", citation).strip()
+                    if report_form and report_form.lower() not in content[:2000].lower():
+                        save_log(
+                            "citation_parallel_report_form_absent",
+                            {
+                                "citation": citation,
+                                "neutral_cite": validate_cite,
+                                "report_form": report_form,
+                                "url": austlii_url,
+                            },
+                        )
+                        content = None
                 if content:
                     url = austlii_url
                     content_valid = True

--- a/litassist/citation_context.py
+++ b/litassist/citation_context.py
@@ -14,7 +14,11 @@ from litassist.citation.cache import (
     _cache_lock,
 )
 from litassist.citation.legislation import normalize_citation
-from litassist.citation.austlii import construct_austlii_url
+from litassist.citation.austlii import (
+    construct_austlii_url,
+    is_traditional_citation_format,
+    resolve_neutral_from_parallel,
+)
 from litassist.citation.trust import is_trusted_legal_host
 import time
 import re
@@ -307,7 +311,9 @@ def _search_and_validate(
         return None, False, None
 
 
-def fetch_citation_context(citations: List[str]) -> tuple[Dict[str, str], List[tuple[str, str]]]:
+def fetch_citation_context(
+    citations: List[str], source_text: Optional[str] = None
+) -> tuple[Dict[str, str], List[tuple[str, str]]]:
     """
     Fetch COMPLETE legal documents for citations with smart source prioritization.
 
@@ -319,6 +325,11 @@ def fetch_citation_context(citations: List[str]) -> tuple[Dict[str, str], List[t
 
     Args:
         citations: List of citations to fetch
+        source_text: optional raw document the citations were extracted from. When
+            given, an authorised-report cite (e.g. "(1999) 201 CLR 1") that has no
+            constructible AustLII URL is resolved to a medium-neutral cite printed
+            parallel to it in source_text (C2 option 1), enabling the direct-AustLII
+            fallback. Omitted/None preserves the prior behaviour exactly.
 
     Returns:
         Tuple of (successful_fetches, failed_citations):
@@ -488,6 +499,23 @@ def fetch_citation_context(citations: List[str]) -> tuple[Dict[str, str], List[t
         # If still no valid content, try direct AustLII URL construction as final fallback (case law only)
         if not content_valid and not is_legislation:
             austlii_url = construct_austlii_url(citation)
+            # C2 option 1: an authorised-report cite (e.g. "(1999) 201 CLR 1") has no
+            # neutral form to build a URL from. If the source document prints the
+            # parallel medium-neutral cite nearby, recover it and build the URL from
+            # that; validation still runs against the original citation.
+            if not austlii_url and source_text and is_traditional_citation_format(citation):
+                neutral_cite = resolve_neutral_from_parallel(citation, source_text)
+                if neutral_cite:
+                    austlii_url = construct_austlii_url(neutral_cite)
+                    if austlii_url:
+                        save_log(
+                            "citation_neutral_resolved_from_parallel",
+                            {
+                                "citation": citation,
+                                "neutral_cite": neutral_cite,
+                                "url": austlii_url,
+                            },
+                        )
             if austlii_url:
                 click.echo("  -> Trying direct AustLII URL")
                 content = _try_fetch_and_validate(austlii_url, citation)

--- a/litassist/citation_context.py
+++ b/litassist/citation_context.py
@@ -527,14 +527,32 @@ def fetch_citation_context(
                 click.echo("  -> Trying direct AustLII URL")
                 content = _try_fetch_and_validate(austlii_url, validate_cite)
                 if content and validate_cite != citation:
-                    # C2-resolved: confirm the fetched page is genuinely a PARALLEL of
-                    # the traditional cite by checking its bare report form appears
-                    # (AustLII prints "[1999] HCA 66; 201 CLR 1", so strip the leading
-                    # year to get "201 CLR 1"). Guards against pairing a same-year but
-                    # unrelated neutral cite - in particular a non-Australian cite (UK
-                    # "[2017] AC 467") must never resolve to an Australian judgment.
+                    # C2-resolved: confirm the fetched page is genuinely the traditional
+                    # cite's PARALLEL. AustLII prints a case's parallel-citation list
+                    # right after its neutral cite in the header
+                    # ("[1999] HCA 66; 201 CLR 1; 168 ALR 86"), so require the
+                    # traditional cite's bare report form ("(1999) 201 CLR 1" -> the
+                    # leading year stripped -> "201 CLR 1") to sit in THAT group, not
+                    # merely anywhere on the page. This is jurisdiction-agnostic: a
+                    # different-jurisdiction report (e.g. Irish "IR" vs Australian
+                    # Industrial Reports "IR") cited deep in the body, or belonging to an
+                    # unrelated same-year case, is not in the page's own parallel list and
+                    # is rejected. Whitespace is collapsed so HTML spacing variants
+                    # (double spaces, newlines, NBSP) do not cause a miss.
                     report_form = re.sub(r"^[\(\[]\d{4}[\)\]]\s*", "", citation).strip()
-                    if report_form and report_form.lower() not in content[:2000].lower():
+                    report_form_norm = re.sub(r"\s+", " ", report_form).lower()
+                    head = re.sub(r"\s+", " ", content[:2000]).lower()
+                    neutral_norm = re.sub(r"\s+", " ", validate_cite).lower()
+                    neutral_pos = head.find(neutral_norm)
+                    # The header citation line ends at the judgment date "(DD Month YYYY)";
+                    # the parallel report cites sit between the neutral cite and that date.
+                    # Bounding the group at the date keeps the catchwords/body that follow
+                    # (which may cite OTHER cases) out of the check. Fall back to a 250-char
+                    # cap if no date marker is found.
+                    tail = head[neutral_pos:neutral_pos + 250] if neutral_pos != -1 else ""
+                    date_marker = re.search(r"\(\s*\d{1,2}\s+[a-z]+\s+\d{4}\s*\)", tail)
+                    parallel_group = tail[: date_marker.start()] if date_marker else tail
+                    if not (report_form_norm and report_form_norm in parallel_group):
                         save_log(
                             "citation_parallel_report_form_absent",
                             {

--- a/litassist/citation_context.py
+++ b/litassist/citation_context.py
@@ -499,15 +499,22 @@ def fetch_citation_context(
         # If still no valid content, try direct AustLII URL construction as final fallback (case law only)
         if not content_valid and not is_legislation:
             austlii_url = construct_austlii_url(citation)
+            # The page we fetch is identified by whatever cite built the URL, so that
+            # is the cite we validate the fetched page against (default: the original).
+            validate_cite = citation
             # C2 option 1: an authorised-report cite (e.g. "(1999) 201 CLR 1") has no
             # neutral form to build a URL from. If the source document prints the
             # parallel medium-neutral cite nearby, recover it and build the URL from
-            # that; validation still runs against the original citation.
+            # that. The fetched page is the NEUTRAL cite's page (AustLII prints the
+            # report cite bare, e.g. "[1999] HCA 66; 201 CLR 1", so the parenthesised
+            # "(1999) 201 CLR 1" never appears verbatim) - so validate against the
+            # neutral cite, then map the document back to the original citation key.
             if not austlii_url and source_text and is_traditional_citation_format(citation):
                 neutral_cite = resolve_neutral_from_parallel(citation, source_text)
                 if neutral_cite:
                     austlii_url = construct_austlii_url(neutral_cite)
                     if austlii_url:
+                        validate_cite = neutral_cite
                         save_log(
                             "citation_neutral_resolved_from_parallel",
                             {
@@ -518,7 +525,7 @@ def fetch_citation_context(
                         )
             if austlii_url:
                 click.echo("  -> Trying direct AustLII URL")
-                content = _try_fetch_and_validate(austlii_url, citation)
+                content = _try_fetch_and_validate(austlii_url, validate_cite)
                 if content:
                     url = austlii_url
                     content_valid = True

--- a/litassist/commands/verify/citation_verifier.py
+++ b/litassist/commands/verify/citation_verifier.py
@@ -62,7 +62,7 @@ def verify_citations(content: str, file: str, output: Optional[str] = None) -> t
         except Exception:
             pass
 
-        case_content, failed_citations = fetch_citation_context(verified_citations)
+        case_content, failed_citations = fetch_citation_context(verified_citations, content)
 
         if case_content:
             click.echo(success_message(f"Fetched content for {len(case_content)} cases"))

--- a/litassist/commands/verify/reasoning_handler.py
+++ b/litassist/commands/verify/reasoning_handler.py
@@ -63,7 +63,7 @@ def verify_reasoning(
         all_citations = extract_citations(content)
         if all_citations:
             click.echo(verifying_message(f"Fetching content for {len(all_citations)} citations..."))
-            case_content, failed_citations = fetch_citation_context(all_citations)
+            case_content, failed_citations = fetch_citation_context(all_citations, content)
             if case_content:
                 click.echo(success_message(f"Fetched content for {len(case_content)} cases"))
             if failed_citations:

--- a/litassist/commands/verify/soundness_checker.py
+++ b/litassist/commands/verify/soundness_checker.py
@@ -59,7 +59,7 @@ def verify_soundness(
         all_citations = extract_citations(content)
         if all_citations:
             click.echo(verifying_message(f"Fetching content for {len(all_citations)} citations..."))
-            case_content, failed_citations = fetch_citation_context(all_citations)
+            case_content, failed_citations = fetch_citation_context(all_citations, content)
             if case_content:
                 click.echo(success_message(f"Fetched content for {len(case_content)} cases"))
             if failed_citations:

--- a/litassist/verification_chain.py
+++ b/litassist/verification_chain.py
@@ -238,8 +238,10 @@ def run_cove_verification(
         )
 
         if citations:
-            # Fetch FULL documents for all citations found
-            legal_context, failed_citations = fetch_citation_context(citations)
+            # Fetch FULL documents for all citations found. Pass the original
+            # document `content` (NOT `questions`, which is LLM-generated and may not
+            # print the parallel neutral cite) so C2 parallel-cite resolution works.
+            legal_context, failed_citations = fetch_citation_context(citations, content)
 
             if legal_context:
                 total_context_size = sum(len(v) for v in legal_context.values())

--- a/tests/unit/test_citation_context_parallel_resolution.py
+++ b/tests/unit/test_citation_context_parallel_resolution.py
@@ -94,6 +94,56 @@ def test_non_australian_traditional_cite_not_false_fetched():
     assert any(cit == citation for cit, _ in failures)
 
 
+def test_cross_jurisdiction_rejected_by_page_parallel_group():
+    """A UK cite next to an unrelated AU neutral cite resolves (nearest), is fetched,
+    but is rejected because "AC 467" is not in the HCA page's own parallel-citation
+    group - even though the page mentions it later in the body, after the judgment
+    date that bounds the group."""
+    citation = "[2017] AC 467"
+    source = "Smith [2017] AC 467; [2017] HCA 5 considered it."
+    hca_page = (
+        "Jones v Roe [2017] HCA 5; 260 CLR 100 (1 February 2017)\n"
+        "High Court of Australia. The Court discussed Smith [2017] AC 467 at length.\n"
+    )
+    context, _failures, mock_fetch = _run(citation, source, hca_page)
+    assert citation not in context
+    assert mock_fetch.called  # fetch attempted, content dropped by the guard
+
+
+def test_false_pairing_rejected_by_page_parallel_group():
+    """A different same-year case's neutral cite is nearest, so the resolver returns it
+    and it is fetched, but the page's parallel group does not list the traditional
+    cite's report form, so it is rejected (no wrong case content served)."""
+    citation = "(2001) 207 CLR 1"
+    source = "A (2001) 207 CLR 1; [2005] HCA 5; B (2005) 223 CLR 1"
+    hca_page = "B v Anor [2005] HCA 5; 223 CLR 1 (1 March 2005)\nHigh Court...\n"
+    context, _failures, mock_fetch = _run(citation, source, hca_page)
+    assert citation not in context
+    assert mock_fetch.called
+
+
+def test_collision_series_rejected_when_not_in_page_parallel_group():
+    # "IR" is both Australian Industrial Reports and Irish Reports. The resolver returns
+    # the nearest neutral cite regardless; the header-group guard rejects it when the
+    # fetched AU page does not list the report form among the neutral cite's parallels.
+    citation = "[2010] 2 IR 1"  # Irish Reports, here
+    source = "Foo [2010] 2 IR 1; [2010] HCA 5 considered."
+    hca_page = "Roe v Doe [2010] HCA 5; 240 CLR 1 (1 January 2010)\nHigh Court...\n"
+    context, _failures, mock_fetch = _run(citation, source, hca_page)
+    assert citation not in context
+    assert mock_fetch.called  # fetch attempted, content dropped by the guard
+
+
+def test_australian_industrial_reports_resolves_when_parallel_on_page():
+    # Same "IR" abbreviation, but genuinely Australian: its report form IS one of the
+    # neutral cite's parallels on the page, so it resolves.
+    citation = "(2010) 200 IR 1"
+    source = "Bar (2010) 200 IR 1; [2010] FCA 5 applied."
+    fca_page = "Union v Employer [2010] FCA 5; 200 IR 1 (1 January 2010)\nFederal Court...\n"
+    context, _failures, _ = _run(citation, source, fca_page)
+    assert citation in context
+
+
 def test_validation_targets_neutral_cite_not_parenthesised_report_cite():
     # The real AustLII header: the report cite is bare "201 CLR 1" and the neutral
     # cite carries the year, so the parenthesised traditional cite is absent.

--- a/tests/unit/test_citation_context_parallel_resolution.py
+++ b/tests/unit/test_citation_context_parallel_resolution.py
@@ -78,6 +78,22 @@ def test_source_text_none_preserves_failure():
     assert failures[0][0] == citation
 
 
+def test_non_australian_traditional_cite_not_false_fetched():
+    """A non-Australian traditional cite (UK Appeal Cases) sitting near an unrelated
+    same-year Australian neutral cite must NOT be resolved to that Australian
+    judgment - the fetched page does not carry the UK cite, so it is not a parallel."""
+    citation = "[2017] AC 467"  # UK; no Australian medium-neutral parallel exists
+    source = "Discussed in Smith [2017] AC 467 and applied locally in Jones [2017] HCA 5."
+    # An HCA page that does NOT contain "AC 467" (it is a different, Australian case).
+    hca_page = (
+        "Jones v Roe [2017] HCA 5; 260 CLR 100; 91 ALJR 1 (1 February 2017)\n"
+        "High Court of Australia\nJudgment text...\n"
+    )
+    context, failures, _ = _run(citation, source, hca_page)
+    assert citation not in context
+    assert any(cit == citation for cit, _ in failures)
+
+
 def test_validation_targets_neutral_cite_not_parenthesised_report_cite():
     # The real AustLII header: the report cite is bare "201 CLR 1" and the neutral
     # cite carries the year, so the parenthesised traditional cite is absent.

--- a/tests/unit/test_citation_context_parallel_resolution.py
+++ b/tests/unit/test_citation_context_parallel_resolution.py
@@ -144,6 +144,17 @@ def test_australian_industrial_reports_resolves_when_parallel_on_page():
     assert citation in context
 
 
+def test_report_form_matched_as_token_not_substring():
+    """The report form must match as a whole token: "20 CLR 1" must not be accepted by
+    a different cite "120 CLR 1" in the page's parallel group (digit concatenation)."""
+    citation = "(1999) 20 CLR 1"
+    source = "Foo (1999) 20 CLR 1; [1999] HCA 66 considered."
+    hca_page = "Bar v Baz [1999] HCA 66; 120 CLR 1 (1 January 1999)\nHigh Court...\n"
+    context, _failures, mock_fetch = _run(citation, source, hca_page)
+    assert citation not in context
+    assert mock_fetch.called
+
+
 def test_validation_targets_neutral_cite_not_parenthesised_report_cite():
     # The real AustLII header: the report cite is bare "201 CLR 1" and the neutral
     # cite carries the year, so the parenthesised traditional cite is absent.

--- a/tests/unit/test_citation_context_parallel_resolution.py
+++ b/tests/unit/test_citation_context_parallel_resolution.py
@@ -5,34 +5,33 @@ source document prints the parallel neutral cite ("[1999] HCA 66") nearby, the
 direct-AustLII fallback resolves the neutral cite, builds the AustLII URL and fetches
 the document. With no source_text the prior behaviour is preserved exactly.
 
-The validation-mechanism test pins WHY the fetched page validates against the
-original CLR cite: the `exact_primary_location` strategy (verbatim string in the page
-body), NOT `_check_header_parallel_citations`, which is dead for CLR/ALR forms. A
-refactor that reorders or drops `exact_primary_location` would silently break C2, so
-this guards it.
+These tests mock the network at the `_fetch_url_content` boundary and let the REAL
+`_validate_citation_match` run, so they exercise the actual validation path. The page
+body uses the real AustLII header form, where the report cite is printed BARE
+("[1999] HCA 66; 201 CLR 1"), so the parenthesised "(1999) 201 CLR 1" never appears
+verbatim. That is why a C2-resolved fetch validates against the resolved NEUTRAL cite
+(verbatim on its own page), not the original traditional cite. Confirmed against the
+live AustLII page for Mann v Carnell on 22/06/2026.
 """
 
 from unittest.mock import MagicMock, patch
 
-from litassist.citation_context import (
-    fetch_citation_context,
-    _validate_citation_match,
-    _check_header_parallel_citations,
-)
+from litassist.citation_context import fetch_citation_context, _validate_citation_match
 from litassist.citation.austlii import construct_austlii_url
 
 HCA_URL = construct_austlii_url("[1999] HCA 66")
 PARALLEL_SOURCE = "Mann v Carnell (1999) 201 CLR 1; [1999] HCA 66 at [12] is in point."
+# Real AustLII header form (report cite bare, neutral cite carries the year).
+AUSTLII_PAGE = (
+    "Mann v Carnell [1999] HCA 66; 201 CLR 1; 168 ALR 86; 74 ALJR 378 "
+    "(21 December 1999)\nHigh Court of Australia\nJudgment text...\n"
+)
 
 
-def _run(citation, source_text, fetch_returns):
-    """fetch_citation_context with the network mocked and every CSE search empty.
-
-    With no CSE items the search loops return without fetching, so the only
-    _try_fetch_and_validate call is the direct-AustLII fallback. construct_austlii_url
-    is NOT patched -- the real one returns "" for the CLR cite and the HCA URL for the
-    resolved neutral cite, which is exactly what C2 depends on.
-    """
+def _run(citation, source_text, page_body):
+    """fetch_citation_context with the network mocked at _fetch_url_content and every
+    CSE search empty, so the only fetch is the direct-AustLII fallback and the REAL
+    validator runs against whatever the fallback fetched."""
     mock_service = MagicMock()
     mock_service.cse.return_value.list.return_value.execute.return_value = {}
     mock_config = MagicMock(
@@ -42,7 +41,7 @@ def _run(citation, source_text, fetch_returns):
     with patch("googleapiclient.discovery.build", return_value=mock_service), patch(
         "litassist.citation_context.get_config", return_value=mock_config
     ), patch(
-        "litassist.citation_context._try_fetch_and_validate", return_value=fetch_returns
+        "litassist.commands.lookup.fetchers._fetch_url_content", return_value=page_body
     ) as mock_fetch, patch(
         "litassist.citation_context.save_log"
     ), patch(
@@ -52,25 +51,26 @@ def _run(citation, source_text, fetch_returns):
     return context, failures, mock_fetch
 
 
-def test_parallel_resolution_enables_austlii_fetch():
+def test_parallel_resolution_fetches_and_validates():
     citation = "(1999) 201 CLR 1"
-    body = f"{citation}; [1999] HCA 66\nHigh Court of Australia. Judgment text..."
 
-    context, failures, mock_fetch = _run(citation, PARALLEL_SOURCE, body)
+    context, failures, mock_fetch = _run(citation, PARALLEL_SOURCE, AUSTLII_PAGE)
 
-    # The neutral cite was resolved and the HCA URL fetched.
-    mock_fetch.assert_called_once_with(HCA_URL, citation)
+    # The neutral cite was resolved, the HCA URL fetched, and the real validator
+    # accepted the page (via the neutral cite verbatim in the body).
+    assert mock_fetch.call_count == 1
+    assert HCA_URL in mock_fetch.call_args[0][0]
     assert citation in context
     assert context[citation]
     assert failures == []
 
 
 def test_source_text_none_preserves_failure():
-    """Without source_text the CLR cite has no constructible URL and still fails -- the
-    default path is unchanged."""
+    """Without source_text the CLR cite has no constructible URL and is never fetched
+    -- the default path is unchanged."""
     citation = "(1999) 201 CLR 1"
 
-    context, failures, mock_fetch = _run(citation, None, "doc body")
+    context, failures, mock_fetch = _run(citation, None, AUSTLII_PAGE)
 
     mock_fetch.assert_not_called()
     assert context == {}
@@ -78,16 +78,10 @@ def test_source_text_none_preserves_failure():
     assert failures[0][0] == citation
 
 
-def test_validation_uses_exact_primary_location_not_parallel_header():
-    # A fetched AustLII page whose body prints the verbatim traditional cite.
-    citation = "(1998) 194 CLR 355"
-    header = (
-        "Project Blue Sky Inc v Australian Broadcasting Authority "
-        "[1998] HCA 28; (1998) 194 CLR 355"
-    )
-    body = header + "\n\nHigh Court of Australia\nJudgment...\n"
-
-    # Validation passes -- via the verbatim string in the body.
-    assert _validate_citation_match(body, citation) is True
-    # ...and NOT via the parallel-citation header strategy, which cannot see CLR forms.
-    assert _check_header_parallel_citations(header, citation) is False
+def test_validation_targets_neutral_cite_not_parenthesised_report_cite():
+    # The real AustLII header: the report cite is bare "201 CLR 1" and the neutral
+    # cite carries the year, so the parenthesised traditional cite is absent.
+    assert _validate_citation_match(AUSTLII_PAGE, "[1999] HCA 66") is True
+    # The parenthesised "(1999) 201 CLR 1" does NOT validate against this page, which
+    # is precisely why a C2-resolved fetch validates against the resolved neutral cite.
+    assert _validate_citation_match(AUSTLII_PAGE, "(1999) 201 CLR 1") is False

--- a/tests/unit/test_citation_context_parallel_resolution.py
+++ b/tests/unit/test_citation_context_parallel_resolution.py
@@ -1,0 +1,93 @@
+"""Tests for C2 option 1 wiring in fetch_citation_context.
+
+When CSE finds nothing for an authorised-report cite like "(1999) 201 CLR 1" and the
+source document prints the parallel neutral cite ("[1999] HCA 66") nearby, the
+direct-AustLII fallback resolves the neutral cite, builds the AustLII URL and fetches
+the document. With no source_text the prior behaviour is preserved exactly.
+
+The validation-mechanism test pins WHY the fetched page validates against the
+original CLR cite: the `exact_primary_location` strategy (verbatim string in the page
+body), NOT `_check_header_parallel_citations`, which is dead for CLR/ALR forms. A
+refactor that reorders or drops `exact_primary_location` would silently break C2, so
+this guards it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from litassist.citation_context import (
+    fetch_citation_context,
+    _validate_citation_match,
+    _check_header_parallel_citations,
+)
+from litassist.citation.austlii import construct_austlii_url
+
+HCA_URL = construct_austlii_url("[1999] HCA 66")
+PARALLEL_SOURCE = "Mann v Carnell (1999) 201 CLR 1; [1999] HCA 66 at [12] is in point."
+
+
+def _run(citation, source_text, fetch_returns):
+    """fetch_citation_context with the network mocked and every CSE search empty.
+
+    With no CSE items the search loops return without fetching, so the only
+    _try_fetch_and_validate call is the direct-AustLII fallback. construct_austlii_url
+    is NOT patched -- the real one returns "" for the CLR cite and the HCA URL for the
+    resolved neutral cite, which is exactly what C2 depends on.
+    """
+    mock_service = MagicMock()
+    mock_service.cse.return_value.list.return_value.execute.return_value = {}
+    mock_config = MagicMock(
+        g_key="fake", cse_id_austlii="cx_austlii", cse_id_comprehensive="cx_comp"
+    )
+
+    with patch("googleapiclient.discovery.build", return_value=mock_service), patch(
+        "litassist.citation_context.get_config", return_value=mock_config
+    ), patch(
+        "litassist.citation_context._try_fetch_and_validate", return_value=fetch_returns
+    ) as mock_fetch, patch(
+        "litassist.citation_context.save_log"
+    ), patch(
+        "litassist.citation_context.time.sleep"
+    ):
+        context, failures = fetch_citation_context([citation], source_text)
+    return context, failures, mock_fetch
+
+
+def test_parallel_resolution_enables_austlii_fetch():
+    citation = "(1999) 201 CLR 1"
+    body = f"{citation}; [1999] HCA 66\nHigh Court of Australia. Judgment text..."
+
+    context, failures, mock_fetch = _run(citation, PARALLEL_SOURCE, body)
+
+    # The neutral cite was resolved and the HCA URL fetched.
+    mock_fetch.assert_called_once_with(HCA_URL, citation)
+    assert citation in context
+    assert context[citation]
+    assert failures == []
+
+
+def test_source_text_none_preserves_failure():
+    """Without source_text the CLR cite has no constructible URL and still fails -- the
+    default path is unchanged."""
+    citation = "(1999) 201 CLR 1"
+
+    context, failures, mock_fetch = _run(citation, None, "doc body")
+
+    mock_fetch.assert_not_called()
+    assert context == {}
+    assert len(failures) == 1
+    assert failures[0][0] == citation
+
+
+def test_validation_uses_exact_primary_location_not_parallel_header():
+    # A fetched AustLII page whose body prints the verbatim traditional cite.
+    citation = "(1998) 194 CLR 355"
+    header = (
+        "Project Blue Sky Inc v Australian Broadcasting Authority "
+        "[1998] HCA 28; (1998) 194 CLR 355"
+    )
+    body = header + "\n\nHigh Court of Australia\nJudgment...\n"
+
+    # Validation passes -- via the verbatim string in the body.
+    assert _validate_citation_match(body, citation) is True
+    # ...and NOT via the parallel-citation header strategy, which cannot see CLR forms.
+    assert _check_header_parallel_citations(header, citation) is False

--- a/tests/unit/test_resolve_neutral_from_parallel.py
+++ b/tests/unit/test_resolve_neutral_from_parallel.py
@@ -1,0 +1,87 @@
+"""
+Tests for resolve_neutral_from_parallel (C2 option 1).
+
+Closes the retrieval gap for authorised-report cites: a CLR-only string like
+`(1999) 201 CLR 1` has no medium-neutral form for `construct_austlii_url` to build
+from, so the direct-AustLII fallback never fires. When the source document prints
+both forms together (the common real-draft case, `... (1999) 201 CLR 1; [1999] HCA
+66`), this resolver recovers the adjacent neutral cite so the existing fetch path can
+run.
+
+Cases mirror the Codex review of the C2 plan: bidirectional window (neutral may
+precede or follow), no year-equality reject (split-year pairs must still resolve),
+nearest-wins on multiple pairs, out-of-window not paired, and non-AustLII neutral
+forms (UK/NZ etc.) excluded because they are not constructible.
+"""
+
+from litassist.citation.austlii import resolve_neutral_from_parallel
+
+
+class TestResolveNeutralFromParallel:
+    def test_neutral_follows_traditional(self):
+        source = "Mann v Carnell (1999) 201 CLR 1; [1999] HCA 66 at [12] held that..."
+        assert (
+            resolve_neutral_from_parallel("(1999) 201 CLR 1", source) == "[1999] HCA 66"
+        )
+
+    def test_neutral_precedes_traditional(self):
+        # Codex check 5: the neutral cite frequently precedes in judgments/headnotes.
+        source = "see [1999] HCA 66; (1999) 201 CLR 1 per Gleeson CJ"
+        assert (
+            resolve_neutral_from_parallel("(1999) 201 CLR 1", source) == "[1999] HCA 66"
+        )
+
+    def test_split_year_pair_still_resolves(self):
+        # Codex check 4: judgment year and report year can differ; a year-equality
+        # reject would silently drop a real, constructible (HCA) resolution.
+        source = "X v Y [1995] HCA 10; (1996) 185 CLR 1 at 7"
+        assert (
+            resolve_neutral_from_parallel("(1996) 185 CLR 1", source) == "[1995] HCA 10"
+        )
+
+    def test_no_neutral_cite_in_window_returns_empty(self):
+        source = "(1996) 185 CLR 1 and then a long passage with no neutral citation."
+        assert resolve_neutral_from_parallel("(1996) 185 CLR 1", source) == ""
+
+    def test_multiple_pairs_nearest_neutral_wins(self):
+        source = (
+            "First A (2001) 207 CLR 1; [2001] HCA 1 and later "
+            "Second B (2005) 223 CLR 1; [2005] HCA 5 distinguished."
+        )
+        assert (
+            resolve_neutral_from_parallel("(2005) 223 CLR 1", source) == "[2005] HCA 5"
+        )
+        assert (
+            resolve_neutral_from_parallel("(2001) 207 CLR 1", source) == "[2001] HCA 1"
+        )
+
+    def test_out_of_window_neutral_not_paired(self):
+        # Neutral cite separated from the traditional cite by far more than the
+        # pairing window must not be treated as parallel.
+        filler = " padding" * 80  # ~640 chars, well beyond the ~300 char window
+        source = f"(1996) 185 CLR 1{filler}[1995] HCA 10"
+        assert resolve_neutral_from_parallel("(1996) 185 CLR 1", source) == ""
+
+    def test_non_austlii_neutral_excluded(self):
+        # UKSC is a valid neutral-FORMAT cite but not an AustLII-constructible court,
+        # so it must not be returned (construct_austlii_url would reject it anyway).
+        source = "(1999) 201 CLR 1; [2016] UKSC 8"
+        assert resolve_neutral_from_parallel("(1999) 201 CLR 1", source) == ""
+
+    def test_empty_inputs_return_empty(self):
+        assert resolve_neutral_from_parallel("", "some text") == ""
+        assert resolve_neutral_from_parallel("(1999) 201 CLR 1", "") == ""
+
+    def test_traditional_cite_absent_from_source(self):
+        source = "totally unrelated text [1999] HCA 66 standing alone"
+        assert resolve_neutral_from_parallel("(1999) 201 CLR 1", source) == ""
+
+    def test_false_pairing_different_case_rejected(self):
+        # A neutral cite belonging to a DIFFERENT case can sit nearest by character
+        # distance; the year gap (2001 vs 2005) marks it as not a parallel cite, so it
+        # must not be paired. Each traditional cite resolves only to its own neutral.
+        source = "A (2001) 207 CLR 1; [2005] HCA 5; B (2005) 223 CLR 1"
+        assert resolve_neutral_from_parallel("(2001) 207 CLR 1", source) == ""
+        assert (
+            resolve_neutral_from_parallel("(2005) 223 CLR 1", source) == "[2005] HCA 5"
+        )

--- a/tests/unit/test_resolve_neutral_from_parallel.py
+++ b/tests/unit/test_resolve_neutral_from_parallel.py
@@ -8,10 +8,13 @@ both forms together (the common real-draft case, `... (1999) 201 CLR 1; [1999] H
 66`), this resolver recovers the adjacent neutral cite so the existing fetch path can
 run.
 
-Cases mirror the Codex review of the C2 plan: bidirectional window (neutral may
-precede or follow), no year-equality reject (split-year pairs must still resolve),
-nearest-wins on multiple pairs, out-of-window not paired, and non-AustLII neutral
-forms (UK/NZ etc.) excluded because they are not constructible.
+The resolver is purely positional: it returns the NEAREST AustLII-constructible
+neutral cite within the window, on either side. It does no jurisdiction or year
+filtering - whether the cite is genuinely the same case is confirmed downstream
+against the fetched page's own parallel-citation list (see
+test_citation_context_parallel_resolution.py). Cases here cover: bidirectional
+window, split-year pairs, nearest-wins on multiple pairs, out-of-window not paired,
+and non-AustLII neutral forms (UK/NZ etc.) excluded because they are not constructible.
 """
 
 from litassist.citation.austlii import resolve_neutral_from_parallel
@@ -32,8 +35,8 @@ class TestResolveNeutralFromParallel:
         )
 
     def test_split_year_pair_still_resolves(self):
-        # Codex check 4: judgment year and report year can differ; a year-equality
-        # reject would silently drop a real, constructible (HCA) resolution.
+        # Judgment year and report year can differ; the resolver does no year filtering,
+        # so the adjacent neutral cite resolves regardless of the one-year gap.
         source = "X v Y [1995] HCA 10; (1996) 185 CLR 1 at 7"
         assert (
             resolve_neutral_from_parallel("(1996) 185 CLR 1", source) == "[1995] HCA 10"
@@ -76,12 +79,21 @@ class TestResolveNeutralFromParallel:
         source = "totally unrelated text [1999] HCA 66 standing alone"
         assert resolve_neutral_from_parallel("(1999) 201 CLR 1", source) == ""
 
-    def test_false_pairing_different_case_rejected(self):
-        # A neutral cite belonging to a DIFFERENT case can sit nearest by character
-        # distance; the year gap (2001 vs 2005) marks it as not a parallel cite, so it
-        # must not be paired. Each traditional cite resolves only to its own neutral.
-        source = "A (2001) 207 CLR 1; [2005] HCA 5; B (2005) 223 CLR 1"
-        assert resolve_neutral_from_parallel("(2001) 207 CLR 1", source) == ""
+    def test_adjacent_parallel_preferred_over_farther(self):
+        # The adjacent neutral cite ([1995] HCA 10) wins over a farther same-year cite
+        # ([1996] HCA 99) - the resolver is nearest-first, nothing more.
+        source = "Cited [1995] HCA 10; (1996) 185 CLR 1 then later [1996] HCA 99 elsewhere"
         assert (
-            resolve_neutral_from_parallel("(2005) 223 CLR 1", source) == "[2005] HCA 5"
+            resolve_neutral_from_parallel("(1996) 185 CLR 1", source) == "[1995] HCA 10"
+        )
+
+    def test_resolver_does_no_jurisdiction_or_case_filtering(self):
+        # The resolver returns the nearest constructible neutral cite WITHOUT judging
+        # whether it is the same case or jurisdiction. Here a UK cite sits next to an
+        # unrelated AU neutral cite: the resolver returns that neutral cite; the cross-
+        # jurisdiction/false-pair REJECTION happens downstream at the page-parallel-group
+        # guard (see test_citation_context_parallel_resolution.py).
+        source = "A (2001) 207 CLR 1; [2005] HCA 5; B (2005) 223 CLR 1"
+        assert (
+            resolve_neutral_from_parallel("(2001) 207 CLR 1", source) == "[2005] HCA 5"
         )


### PR DESCRIPTION
## What

Closes the first slice of the ROADMAP Phase 2 retrieval gap (TODO C2). An
authorised-report citation like `(1999) 201 CLR 1` has no medium-neutral form, so
`construct_austlii_url` returns `""` and the direct-AustLII fallback never fires;
`verify --soundness`/`--reasoning` and CoVe then run with no document context for
those cites. When the source document prints both citation forms together (the common
real-draft case, `... (1999) 201 CLR 1; [1999] HCA 66`), this recovers the neutral
cite and uses the existing fetch path.

## How

- `resolve_neutral_from_parallel(traditional_cite, source_text)` in
  `litassist/citation/austlii.py`: finds a medium-neutral cite printed parallel to the
  traditional cite within a bidirectional window, validated through
  `construct_austlii_url` (so only AustLII-constructible courts, never the traditional
  cite itself). Hoists the shared neutral-cite regex to one module constant.
- `fetch_citation_context` gains an optional `source_text`; the direct-AustLII fallback
  uses it when the cite is traditional and has no constructible URL. Default `None`
  preserves prior behaviour for every caller.
- The four real callers pass the original document: `run_cove_verification` passes
  `content` (not the LLM-generated `questions`), plus the three `verify` handlers.

## Correctness guards (each added after a review/live finding)

- **Year proximity (+/-1):** parallel cites name one judgment, so years match or differ
  by at most one. Rejects a different same-year-ish case sitting in the window.
- **Validation target:** a live AustLII fetch showed the page prints the report cite
  bare (`[1999] HCA 66; 201 CLR 1`), so the parenthesised `(1999) 201 CLR 1` never
  appears verbatim. A C2-resolved fetch is validated against the resolved neutral cite,
  then mapped back to the original citation key.
- **Parallelism guard (cross-jurisdiction):** a C2-resolved page is accepted only if it
  carries the traditional cite's bare report form in its header, so a non-Australian
  cite (`[2017] AC 467`) near an unrelated Australian neutral cite (`[2017] HCA 5`)
  cannot false-fetch the wrong judgment.

## Verification

- Offline unit tests: `tests/unit/test_resolve_neutral_from_parallel.py` (incl.
  bidirectional, split-year, false-pairing, cross-jurisdiction) and
  `tests/unit/test_citation_context_parallel_resolution.py` (mock at `_fetch_url_content`
  so the real validator runs). Full suite 558 passing; `ruff` clean.
- Live AustLII (residential IP): `fetch_citation_context(["(1999) 201 CLR 1"], source)`
  returns 122903 chars of the Mann v Carnell judgment; the no-`source_text` control
  still fails; the cross-jurisdiction case is rejected.

## Scope / limitations

- Option 1 only fires when the neutral cite is present in the source. A deliberately
  CLR-only document (including the P-JUDGE `authorised_report` fixture) is not resolved;
  that needs option 2 (LawCite citator), which stays deferred/gated.
- Residual: the parallelism guard matches the report form in the first 2000 chars, so a
  very short token could in principle match an unrelated page's catchwords (low
  probability; noted in TODO).

Docs updated: CHANGELOG, ROADMAP Phase 2, TODO C1/C2, JUDGE_EVAL.