### PR TITLE
P-FAITH: long-context faithfulness checker for verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated: 28/06/2026
+Last updated: 14/07/2026
 
 All notable changes to LitAssist will be documented in this file.
 
@@ -22,8 +22,9 @@ Historical dated sections preserve the model names that were current when those 
   a pure, offline-tested `score_faithfulness` aggregates the score (placeholders are
   neutral). When claims are unsupported or contradicted, a SEPARATE addendum file is
   written (`verify_faithfulness_addendum`); the original document is never rewritten.
-  `--faithfulness` is opt-in and fails fast without `--reference`; the `--reference`
-  flag's meaning is tightened to "source documents". New prompt keys
+  `--faithfulness` is opt-in and fails fast without `--reference` or when the
+  `--reference` pattern matches no readable files; the `--reference` flag's meaning is
+  tightened to "source documents". New prompt keys
   `verification.faithfulness.*` and model roles `faithfulness-claims` (Sonnet 4.6),
   `faithfulness-align` (GPT-5.5), `faithfulness-addendum` (Sonnet 4.6). ROADMAP P-FAITH.
 - Authorised-report citation retrieval (C2 option 1). `fetch_citation_context` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Last updated: 22/06/2026
+Last updated: 28/06/2026
 
 All notable changes to LitAssist will be documented in this file.
 
@@ -12,6 +12,20 @@ Historical dated sections preserve the model names that were current when those 
 ## [Unreleased]
 
 ### Added
+- Long-context faithfulness check (P-FAITH). `verify FILE --faithfulness --reference
+  <sources>` checks whether the document's factual claims are grounded in the supplied
+  source documents - a failure mode distinct from citation validity.
+  `run_faithfulness_verification` (`litassist/verification_chain.py`) runs staged calls
+  (extract atomic claims, classify each against the sources as
+  supported/unsupported/contradicted/placeholder, and - only when claims are flagged -
+  draft a corrective addendum) and
+  a pure, offline-tested `score_faithfulness` aggregates the score (placeholders are
+  neutral). When claims are unsupported or contradicted, a SEPARATE addendum file is
+  written (`verify_faithfulness_addendum`); the original document is never rewritten.
+  `--faithfulness` is opt-in and fails fast without `--reference`; the `--reference`
+  flag's meaning is tightened to "source documents". New prompt keys
+  `verification.faithfulness.*` and model roles `faithfulness-claims` (Sonnet 4.6),
+  `faithfulness-align` (GPT-5.5), `faithfulness-addendum` (Sonnet 4.6). ROADMAP P-FAITH.
 - Authorised-report citation retrieval (C2 option 1). `fetch_citation_context` now
   takes an optional `source_text`; when an authorised-report cite like
   `(1999) 201 CLR 1` has no constructible AustLII URL, `resolve_neutral_from_parallel`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # LitAssist Feature Roadmap
 
-Last updated: 21/06/2026
+Last updated: 28/06/2026
 **Status:** Strategic planning; roadmap items are aspirational unless marked DONE, PARTIALLY SUPERSEDED, or already implemented elsewhere
 **Confidence:** 0.88
 
@@ -268,8 +268,8 @@ P-JUDGE is built **first** as the measurement keystone. Without a repeatable
 offline eval, every other "quality" change here is judged by vibes (this
 roadmap's own framing: "measured vs guessed at"). P1-12 then ships **only if**
 P-JUDGE shows its 2-4x-cost cross-check actually improves output over the existing
-three-stage verify; P2-19 reuses P1-12's plumbing. P-FAITH is a sibling,
-sequenced as capacity allows. Rationale: P2-19 depends on P1-12, and neither is
+three-stage verify; P2-19 reuses P1-12's plumbing. P-FAITH was a sibling, now
+SHIPPED (28/06/2026). Rationale: P2-19 depends on P1-12, and neither is
 falsifiable without P-JUDGE - so committing the ensemble spend before the
 measurement that justifies it is the inversion this re-sequence corrects.
 
@@ -413,7 +413,13 @@ The historical design intent follows, retained for context.
 
 ---
 
-### P-FAITH: Long-Context Faithfulness Checker [NEW - 04/06/2026]
+### P-FAITH: Long-Context Faithfulness Checker [SHIPPED 28/06/2026]
+**Status:** Shipped on branch `feat/p-faith-faithfulness`. `verify FILE
+--faithfulness --reference <sources>` extracts the document's atomic claims,
+classifies each against the source documents, scores faithfulness, and writes a
+per-claim report plus a separate corrective addendum when claims are flagged. The
+original document is never rewritten. Pure scoring core is offline-unit-tested;
+the staged orchestrator and CLI wiring have mocked integration tests.
 **Effort:** 10-14 hours
 **Priority:** HIGH
 
@@ -436,20 +442,20 @@ facts - no drift, no silent omission, no invented specifics beyond the existing
 - Aggregate a document faithfulness score
 - Flag unsupported specifics (ties into the anti-hallucination placeholder rule)
 
-**Implementation:**
-- Extend `litassist/verification_chain.py`, reusing the multi-stage pipeline
-  pattern of `run_cove_verification()`
-- Load the `--sources` files through the existing supplied-file path
-  (`litassist/utils/file_ops.py:read_document()` plus an `expand_glob_*` callback, as
-  `draft` already does via `litassist/commands/draft/document_processor.py`) - these are
-  the documents claims are checked against. Optionally pull cited-authority
-  context via `citation_context.py:fetch_citation_context()` as a secondary
-  source, but it is not the primary `--sources` loader
-- New flag: `la verify --input draft.md --faithfulness --sources case_facts.md`
-- New prompt keys under `litassist/prompts/verification.yaml` (e.g. `claim_extraction`,
-  `faithfulness_alignment`)
-- LLM: Claude Sonnet 4.6 (claim extraction) + GPT-5.5 (cross-check)
-- Output: Per-claim table + faithfulness score + flagged sections
+**Implementation (as shipped):**
+- `run_faithfulness_verification()` in `litassist/verification_chain.py`, reusing the
+  multi-stage pattern of `run_cove_verification()`; plus a pure, offline-tested
+  `score_faithfulness()` scoring core
+- Sources are the existing `--reference` files (no new `--sources` flag - the flag was
+  reused and its meaning tightened to "source documents"), loaded via the verify
+  command's existing `process_reference_files()` path
+- Flag: `verify FILE --faithfulness --reference case_facts.md` (positional `FILE`, not
+  `--input`); opt-in and fails fast without `--reference`
+- New prompt keys `verification.faithfulness.{claim_extraction,alignment,addendum}`;
+  model roles `faithfulness-claims` (Sonnet 4.6), `faithfulness-align` (GPT-5.5),
+  `faithfulness-addendum` (Sonnet 4.6)
+- Output: per-claim report + faithfulness score (placeholders neutral) + a SEPARATE
+  corrective addendum when claims are flagged; the original document is never rewritten
 
 ---
 
@@ -1404,7 +1410,7 @@ la profile --create "Agency A" --type government
    **P-JUDGE Eval Harness FIRST** (keystone; calibrate baseline) -> P1-12
    Multi-Model Cross-Checks, shipped **only if** P-JUDGE shows lift > cost ->
    P2-19 Bias Divergence Detector (thin add on P1-12) -> P-FAITH Long-Context
-   Faithfulness as capacity allows.
+   Faithfulness [SHIPPED 28/06/2026].
 4. Phase 3 Citation & Compliance as capacity allows
    (Phase 4 Professional Complaints stays dormant unless step 0 says otherwise.)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # LitAssist Development TODO
 
-Last updated: 22/06/2026
+Last updated: 28/06/2026
 
 **Note:** Strategic feature planning (litigation support, advisory capabilities, new commands) is now in [ROADMAP.md](ROADMAP.md). This file focuses on bugs, technical debt, and code quality improvements.
 
@@ -11,6 +11,10 @@ Model Quality & Research, **re-sequenced measurement-first**. **P-JUDGE SHIPPED
 baseline; see `docs/development/JUDGE_EVAL.md`). P1-12 cross-checks were built and
 then **REMOVED 17/06/2026** (evaluated, no unique value over plain
 `verify --reference`); P2-19 divergence is parked. P-JUDGE stays as the keystone.
+**P-FAITH SHIPPED 28/06/2026** on branch `feat/p-faith-faithfulness`
+(`verify FILE --faithfulness --reference <sources>`: per-claim grounding check +
+separate corrective addendum; `run_faithfulness_verification` +
+`score_faithfulness` in `litassist/verification_chain.py`).
 De-risk track done: CSE->Vertex scoping validated 10/06/2026 (below) and licensing
 resolved as MIT 10/06/2026. P-JUDGE's benchmark seeds the un-fetchable citation
 classes (authorised-report CLR-only cites, a confabulated citation, overseas
@@ -110,7 +114,7 @@ cookie-reuse lands. See ROADMAP P-JUDGE.
 3. Review ongoing prompt optimization opportunities (October 2025 model strategy implemented)
 4. **Pricing-aware features:** `litassist/llm/model_capabilities.yaml` already carries `input_price_per_mtok` and `output_price_per_mtok` per model (refreshable via `litassist refresh`). Consume them for per-call cost logging, a `--budget` flag, cost-aware model selection, and a cost field in the audit log. **Actual per-call cost now captured (17/06/2026):** the local price-table estimator `cost.py:estimate_call_cost` was removed; `litassist/llm/usage.py` records OpenRouter's real billed `usage.cost` per call (summed across internal billed SDK calls) into the audit log. Still to add: a `--budget` flag and cost-aware model selection built on those captured costs.
 5. See ROADMAP.md for strategic feature implementation planning
-6. **Roadmap restructure (04/06/2026 - no active litigation):** ROADMAP.md is research-led, with professional complaints demoted to the dormant backlog pending the [URGENT] tool-assessment above. Phase order: (1) Matter Foundation, (2) Model Quality & Research [LEAD], (3) Citation & Compliance, (4) Professional Complaints (DEFERRED/dormant), (5) Litigation Tooling (DORMANT), (6) FOI (deprioritised) + Infrastructure. P-IDs are now stable handles (not phase indicators). Code-touching items relevant to this file: **P1-12 Multi-Model Cross-Checks shipped behind `verify --cross-check` (13/06/2026) as a NEW read-only module `litassist/commands/verify/ensemble.py`, NOT an extension of `verification_chain.py`** (the ensemble compares, it does not rewrite); P2-19 Bias Divergence Detector will reuse that module; the new **P-FAITH** Long-Context Faithfulness Checker extends `litassist/verification_chain.py` (reusing `run_cove_verification()` + `citation_context.py:fetch_citation_context()`); the new **P-JUDGE** LLM-as-Judge eval harness lands as a real-API `test-scripts/test_judge_eval.py` building on `test_quality.py`. Deprioritised: P0A-2 (-> P3, dormant), P2-16 FOI (-> LOW). Dropped: P1-14 Evidence Chain Tracker. Full detail and dependency notes in ROADMAP.md.
+6. **Roadmap restructure (04/06/2026 - no active litigation):** ROADMAP.md is research-led, with professional complaints demoted to the dormant backlog pending the [URGENT] tool-assessment above. Phase order: (1) Matter Foundation, (2) Model Quality & Research [LEAD], (3) Citation & Compliance, (4) Professional Complaints (DEFERRED/dormant), (5) Litigation Tooling (DORMANT), (6) FOI (deprioritised) + Infrastructure. P-IDs are now stable handles (not phase indicators). Code-touching items relevant to this file: **P1-12 Multi-Model Cross-Checks shipped behind `verify --cross-check` (13/06/2026) as a NEW read-only module `litassist/commands/verify/ensemble.py`, NOT an extension of `verification_chain.py`** (the ensemble compares, it does not rewrite); P2-19 Bias Divergence Detector will reuse that module; **P-FAITH** Long-Context Faithfulness Checker SHIPPED 28/06/2026, extending `litassist/verification_chain.py` (`run_faithfulness_verification()` reusing the `run_cove_verification()` staged pattern; sources are the reused `--reference` files, not a new `--sources` flag); the new **P-JUDGE** LLM-as-Judge eval harness lands as a real-API `test-scripts/test_judge_eval.py` building on `test_quality.py`. Deprioritised: P0A-2 (-> P3, dormant), P2-16 FOI (-> LOW). Dropped: P1-14 Evidence Chain Tracker. Full detail and dependency notes in ROADMAP.md.
 7. **Phase 2 re-sequence (09/06/2026 - approved plan, measurement-first):** within the Model Quality & Research thrust, **P-JUDGE is built first** as the measurement keystone; P1-12 cross-checks ship **only if** P-JUDGE shows lift > cost; P2-19 divergence is a thin add reusing P1-12's `litassist/commands/verify/ensemble.py`. Corrects the prior ordering (which committed the ensemble spend before the eval that justifies it). The two new `verify` flags (`--cross-check`, `--divergence-check`/`--models`) attach to the **positional FILE** arg (not `--input`) and must be added to `test-scripts/test_cli_comprehensive.sh`. See ROADMAP Phase 2 + Next Steps.
 
 ## Future Plans

--- a/docs/development/STATIC_ANALYSIS_DEBT.md
+++ b/docs/development/STATIC_ANALYSIS_DEBT.md
@@ -1,0 +1,25 @@
+# Static Analysis Debt
+
+Last updated: 26/06/2026
+
+Pyright diagnostics that exist in the codebase and are recorded here to address
+later. They were surfaced (not introduced) during the P-FAITH work on branch
+`feat/p-faith-faithfulness` when `litassist/verification_chain.py` was edited and the
+linter re-ran over the whole file. None is a known runtime defect today, but each is
+real and ours to clean up. Priority: LOW (no observed misbehaviour); fix in a
+dedicated pass, not bundled into feature commits.
+
+## `litassist/verification_chain.py`
+
+| Line | Diagnostic | Detail | Runtime risk |
+|------|------------|--------|--------------|
+| 88 | `model_name` is not accessed | In `run_verification_chain` stage 3, `corrected_content, model_name = client.verify(...)` binds `model_name` but it is never used. | None. Dead variable; the soundness/cove handlers capture and log their model name, this stage does not. Either log it or discard with `_`. |
+| 433-435 | `answers_prompt` possibly unbound | In `run_cove_verification`, `answers_prompt` is assigned inside the `while answers is None and attempts < 5:` loop (line 324) and read after the loop in `cove_stages["answers"]`. | None at runtime: the loop always executes at least once (`attempts` starts at 0). Static analysis cannot prove it. Initialise `answers_prompt = ""` before the loop to satisfy the checker. |
+| 576 | `usage4` possibly unbound | In `run_cove_verification`'s summary `total_tokens`, `usage4` is assigned only inside the `if not passed:` regeneration block and read in the summary. | None at runtime: guarded by `if not passed and "usage4" in locals()`. The `locals()` guard is what trips the checker. Hoist `usage4 = {}` before the branch and drop the `in locals()` check. |
+
+## How to clear
+
+A single focused commit that initialises the loop/branch variables and removes or
+uses `model_name` -- no behavioural change, just making the static checker agree with
+the runtime invariants. Verify with `pytest` (the CoVe tests already cover these
+paths) and a clean Pyright pass on the file.

--- a/docs/development/STATIC_ANALYSIS_DEBT.md
+++ b/docs/development/STATIC_ANALYSIS_DEBT.md
@@ -4,10 +4,13 @@ Last updated: 26/06/2026
 
 Pyright diagnostics that exist in the codebase and are recorded here to address
 later. They were surfaced (not introduced) during the P-FAITH work on branch
-`feat/p-faith-faithfulness` when `litassist/verification_chain.py` was edited and the
-linter re-ran over the whole file. None is a known runtime defect today, but each is
-real and ours to clean up. Priority: LOW (no observed misbehaviour); fix in a
-dedicated pass, not bundled into feature commits.
+`feat/p-faith-faithfulness` when files were edited and the linter re-ran over them.
+None is a known runtime defect today, but each is real and ours to clean up.
+Priority: LOW (no observed misbehaviour); fix in a dedicated pass, not bundled into
+feature commits.
+
+Standing rule: any diagnostic surfaced but not actioned in the commit that surfaced
+it is logged HERE, not just mentioned in passing.
 
 ## `litassist/verification_chain.py`
 
@@ -16,6 +19,12 @@ dedicated pass, not bundled into feature commits.
 | 88 | `model_name` is not accessed | In `run_verification_chain` stage 3, `corrected_content, model_name = client.verify(...)` binds `model_name` but it is never used. | None. Dead variable; the soundness/cove handlers capture and log their model name, this stage does not. Either log it or discard with `_`. |
 | 433-435 | `answers_prompt` possibly unbound | In `run_cove_verification`, `answers_prompt` is assigned inside the `while answers is None and attempts < 5:` loop (line 324) and read after the loop in `cove_stages["answers"]`. | None at runtime: the loop always executes at least once (`attempts` starts at 0). Static analysis cannot prove it. Initialise `answers_prompt = ""` before the loop to satisfy the checker. |
 | 576 | `usage4` possibly unbound | In `run_cove_verification`'s summary `total_tokens`, `usage4` is assigned only inside the `if not passed:` regeneration block and read in the summary. | None at runtime: guarded by `if not passed and "usage4" in locals()`. The `locals()` guard is what trips the checker. Hoist `usage4 = {}` before the branch and drop the `in locals()` check. |
+
+## `tests/unit/test_yaml_prompt_validation.py`
+
+| Line | Diagnostic | Detail | Runtime risk |
+|------|------------|--------|--------------|
+| 253 | `prompts_dir` is not accessed | A local bound in the validation loop is never read. | None. Test-only unused local; discard with `_` or remove the binding. |
 
 ## How to clear
 

--- a/docs/development/STATIC_ANALYSIS_DEBT.md
+++ b/docs/development/STATIC_ANALYSIS_DEBT.md
@@ -20,6 +20,13 @@ it is logged HERE, not just mentioned in passing.
 | 433-435 | `answers_prompt` possibly unbound | In `run_cove_verification`, `answers_prompt` is assigned inside the `while answers is None and attempts < 5:` loop (line 324) and read after the loop in `cove_stages["answers"]`. | None at runtime: the loop always executes at least once (`attempts` starts at 0). Static analysis cannot prove it. Initialise `answers_prompt = ""` before the loop to satisfy the checker. |
 | 576 | `usage4` possibly unbound | In `run_cove_verification`'s summary `total_tokens`, `usage4` is assigned only inside the `if not passed:` regeneration block and read in the summary. | None at runtime: guarded by `if not passed and "usage4" in locals()`. The `locals()` guard is what trips the checker. Hoist `usage4 = {}` before the branch and drop the `in locals()` check. |
 
+## `litassist/commands/verify/core.py`
+
+| Line | Diagnostic | Detail | Runtime risk |
+|------|------------|--------|--------------|
+| ~165 | `verified`, `unverified` not accessed | The citation stage unpacks `(..., verified, unverified) = verify_citations(...)` but neither is used downstream. | None. Unused unpack targets; replace with `_`. |
+| ~175 | `existing_trace` not accessed | The reasoning stage unpacks `existing_trace` from `verify_reasoning(...)` and never uses it. | None. Unused unpack target; replace with `_`. |
+
 ## `tests/unit/test_yaml_prompt_validation.py`
 
 | Line | Diagnostic | Detail | Runtime risk |

--- a/docs/user/LitAssist_Reference_Manual.md
+++ b/docs/user/LitAssist_Reference_Manual.md
@@ -1,6 +1,6 @@
 # LitAssist Reference Manual
 
-Last updated: 17/06/2026
+Last updated: 26/06/2026
 
 ---
 
@@ -1500,16 +1500,19 @@ litassist verify <file> [OPTIONS]
 | `--soundness` | flag | Verify legal soundness only |
 | `--reasoning` | flag | Verify/generate reasoning trace only |
 | `--cove` | flag | Add Chain of Verification as final check |
-| `--reference` | glob | Reference files for context (required to detect fabricated facts) |
+| `--faithfulness` | flag | Check the document's claims are grounded in the `--reference` sources (requires `--reference`) |
+| `--reference` | glob | Source documents (the ground truth) used as context across stages and, with `--faithfulness`, the documents the claims are checked against |
 | `--cove-reference` | glob | Reference files for CoVe answer stage (requires `--cove`) |
 | `--heavy` | flag | Use GPT-5.5 for reasoning and soundness |
 | `--output` | text | Custom output filename prefix |
 
 **Default behaviour:**
 
-With no flags, all three verifications run: citations, soundness, and reasoning.
+With no flags, three verifications run: citations, soundness, and reasoning.
 Individual flags select specific checks. The `--cove` flag adds CoVe as an
-additional stage after the selected checks.
+additional stage after the selected checks. `--faithfulness` is opt-in: it requires
+`--reference` and, when passed on its own, runs only the faithfulness check (it does
+not enable the default three).
 
 **Detecting fabricated facts (`--reference`):**
 
@@ -1543,14 +1546,28 @@ The `--heavy` flag substitutes GPT-5.5 (with maximum reasoning effort) for the
 reasoning and soundness stages. This provides the highest quality verification at
 higher cost.
 
+**Faithfulness check (`--faithfulness`):**
+
+`--faithfulness` checks whether the document's factual claims are grounded in the
+`--reference` source documents - a failure mode distinct from citation validity (a
+real, verified citation can still be misapplied to the facts). It extracts the
+document's atomic claims, classifies each against the sources as supported,
+unsupported, contradicted, or placeholder, and writes a per-claim report with a
+faithfulness score. Placeholders (the `[... TO BE PROVIDED]` convention) are neutral
+and do not lower the score. When claims are unsupported or contradicted, a separate
+corrective **addendum** is written (`verify_faithfulness_addendum`); the original
+document is never rewritten. Requires `--reference`; fails fast without it.
+
 **Reference files:**
 
-The `--reference` option provides additional documents as context during
-verification. This is useful when the document being verified references exhibits,
-affidavits, or other materials that the verifier needs to see.
+The `--reference` option provides the source documents (the ground truth) as context
+during verification. This is useful when the document being verified references
+exhibits, affidavits, or other materials that the verifier needs to see, and it is
+the documents `--faithfulness` checks the claims against.
 
 **Models:** GPT-5.5 (citations), Claude Opus 4.7 (soundness), Claude Sonnet 4.6
-(reasoning), GPT-5.5 (heavy mode)
+(reasoning), GPT-5.5 (heavy mode), Claude Sonnet 4.6 + GPT-5.5 (faithfulness:
+claim extraction + grounding classification)
 
 **Smith v Jones example:**
 

--- a/docs/user/LitAssist_Reference_Manual.md
+++ b/docs/user/LitAssist_Reference_Manual.md
@@ -1,6 +1,6 @@
 # LitAssist Reference Manual
 
-Last updated: 26/06/2026
+Last updated: 14/07/2026
 
 ---
 
@@ -1556,7 +1556,8 @@ unsupported, contradicted, or placeholder, and writes a per-claim report with a
 faithfulness score. Placeholders (the `[... TO BE PROVIDED]` convention) are neutral
 and do not lower the score. When claims are unsupported or contradicted, a separate
 corrective **addendum** is written (`verify_faithfulness_addendum`); the original
-document is never rewritten. Requires `--reference`; fails fast without it.
+document is never rewritten. Requires `--reference`; fails fast without it, and when
+the `--reference` pattern matches no readable files.
 
 **Reference files:**
 

--- a/litassist/commands/verify/__init__.py
+++ b/litassist/commands/verify/__init__.py
@@ -22,11 +22,16 @@ from .core import run_verification_workflow
 @click.option("--soundness", is_flag=True, help="Verify legal soundness only")
 @click.option("--reasoning", is_flag=True, help="Verify/generate reasoning trace only")
 @click.option("--cove", is_flag=True, help="Add Chain of Verification as final check")
+@click.option(
+    "--faithfulness",
+    is_flag=True,
+    help="Check the document's factual claims are grounded in the --reference source documents (requires --reference)."
+)
 @click.option("--output", type=str, help="Custom output filename prefix")
 @click.option(
     "--reference",
     type=str,
-    help="Glob pattern for reference files to include as context (e.g., '*.txt', 'docs/*.pdf'). Supports PDF and text files."
+    help="Glob pattern for the source documents (the ground truth), used as context across stages and, with --faithfulness, the documents the claims are checked against (e.g., '*.txt', 'docs/*.pdf'). Supports PDF and text files."
 )
 @click.option(
     "--cove-reference",
@@ -39,16 +44,25 @@ from .core import run_verification_workflow
     help="Use verification-heavy mode (max thinking effort for reasoning and soundness stages)"
 )
 @timed
-def verify(file, citations, soundness, reasoning, cove, output, reference, cove_reference, heavy):
+def verify(file, citations, soundness, reasoning, cove, faithfulness, output, reference, cove_reference, heavy):
     """
     Verify legal text for citations, soundness, and reasoning.
 
-    By default, performs all three verification types.
-    Use flags to run specific verifications only.
+    By default, performs citations, soundness, and reasoning.
+    Use flags to run specific verifications only. --faithfulness is opt-in and
+    requires --reference source documents.
     """
-    # If no specific verification flags are set, enable all
-    if not any([citations, soundness, reasoning]):
+    # If no specific verification flags are set, enable the default three. --faithfulness
+    # counts as a selection so that "verify FILE --faithfulness" runs ONLY faithfulness.
+    if not any([citations, soundness, reasoning, faithfulness]):
         citations = soundness = reasoning = True
+
+    # Faithfulness checks the document against supplied sources; without them there is
+    # nothing to check against, so fail fast rather than silently degrade.
+    if faithfulness and not reference:
+        raise click.ClickException(
+            "--faithfulness requires --reference source documents to check the document against."
+        )
 
     # Run the verification workflow
     run_verification_workflow(
@@ -57,6 +71,7 @@ def verify(file, citations, soundness, reasoning, cove, output, reference, cove_
         soundness=soundness,
         reasoning=reasoning,
         cove=cove,
+        faithfulness=faithfulness,
         output=output,
         reference=reference,
         cove_reference=cove_reference,

--- a/litassist/commands/verify/core.py
+++ b/litassist/commands/verify/core.py
@@ -223,7 +223,7 @@ def run_verification_workflow(
     # 4. Chain of Verification (Final Stage)
     if cove:
         # Skip CoVe if only citations are being verified
-        if citations and not soundness and not reasoning:
+        if citations and not soundness and not reasoning and not faithfulness:
             click.echo(
                 warning_message(
                     "CoVe skipped: --cove flag is ignored when only verifying citations"

--- a/litassist/commands/verify/core.py
+++ b/litassist/commands/verify/core.py
@@ -124,6 +124,15 @@ def run_verification_workflow(
         except Exception:
             pass
 
+    # The CLI guarantees --faithfulness came with --reference, but the glob can still
+    # match no readable files. Checking claims against empty sources would spend LLM
+    # calls to grade everything UNSUPPORTED, so fail fast instead.
+    if faithfulness and not reference_context.strip():
+        raise click.ClickException(
+            "--faithfulness: the --reference pattern matched no readable source "
+            "documents to check the document against."
+        )
+
     # Process CoVe reference files if provided
     cove_reference_context, cove_reference_files = process_reference_files(
         cove_reference,

--- a/litassist/commands/verify/core.py
+++ b/litassist/commands/verify/core.py
@@ -21,6 +21,7 @@ from litassist.verification_chain import run_cove_verification, format_cove_repo
 from .citation_verifier import verify_citations
 from .reasoning_handler import verify_reasoning
 from .soundness_checker import verify_soundness
+from .faithfulness_handler import verify_faithfulness
 
 
 def handle_verification_error(step_name: str, exception: Exception) -> None:
@@ -36,6 +37,7 @@ def run_verification_workflow(
     soundness: bool,
     reasoning: bool,
     cove: bool,
+    faithfulness: bool = False,
     output: Optional[str] = None,
     reference: Optional[str] = None,
     cove_reference: Optional[str] = None,
@@ -50,6 +52,7 @@ def run_verification_workflow(
         soundness: Whether to verify soundness
         reasoning: Whether to verify reasoning
         cove: Whether to run Chain of Verification
+        faithfulness: Whether to check claims are grounded in the --reference sources
         output: Optional custom output filename prefix
         reference: Optional reference file glob pattern
         cove_reference: Optional CoVe reference file glob pattern
@@ -65,7 +68,7 @@ def run_verification_workflow(
             "init",
             "start",
             "Starting verification command",
-            {"stages": f"citations={citations}, soundness={soundness}, reasoning={reasoning}, cove={cove}"}
+            {"stages": f"citations={citations}, soundness={soundness}, reasoning={reasoning}, cove={cove}, faithfulness={faithfulness}"}
         )
     except Exception:
         pass
@@ -192,6 +195,21 @@ def run_verification_workflow(
         except Exception as e:
             handle_verification_error("Legal soundness check", e)
             failed_stages.append(("Legal soundness check", str(e)))
+
+    # 3b. Faithfulness check (claims grounded in the --reference sources)
+    if faithfulness:
+        try:
+            (_, _, faithfulness_file,
+             faithfulness_addendum_file) = verify_faithfulness(
+                content, file, reference_context, output
+            )
+            extra_files["Faithfulness report"] = faithfulness_file
+            if faithfulness_addendum_file:
+                extra_files["Faithfulness addendum"] = faithfulness_addendum_file
+            reports_generated += 1
+        except Exception as e:
+            handle_verification_error("Faithfulness check", e)
+            failed_stages.append(("Faithfulness check", str(e)))
 
     # 4. Chain of Verification (Final Stage)
     if cove:
@@ -321,6 +339,7 @@ def run_verification_workflow(
                         "soundness": soundness,
                         "reasoning": reasoning,
                         "cove": cove,
+                        "faithfulness": faithfulness,
                         "reference": reference,
                         "cove_reference": cove_reference,
                     },

--- a/litassist/commands/verify/faithfulness_handler.py
+++ b/litassist/commands/verify/faithfulness_handler.py
@@ -1,0 +1,101 @@
+"""
+Faithfulness verification for verify command (P-FAITH).
+
+Checks whether the document's factual claims are grounded in the supplied source
+documents (the --reference files). Saves a per-claim report and, when claims are
+flagged, a separate corrective addendum. The original document is never modified.
+"""
+
+import os
+from typing import Optional
+import click
+from litassist.logging import save_command_output, log_task_event
+from litassist.utils.formatting import verifying_message
+from litassist.verification_chain import (
+    run_faithfulness_verification,
+    format_faithfulness_report,
+)
+
+
+def verify_faithfulness(
+    content: str,
+    file: str,
+    sources_context: str,
+    output: Optional[str] = None,
+) -> tuple:
+    """
+    Check whether the document's claims are grounded in the source documents.
+
+    Args:
+        content: Document content to verify
+        file: Original file path
+        sources_context: The --reference source documents the claims are checked against
+        output: Optional custom output filename prefix
+
+    Returns:
+        tuple: (faithfulness_data, score, report_file, addendum_file)
+    """
+    click.echo(verifying_message("Starting faithfulness check..."))
+
+    try:
+        log_task_event(
+            "verify", "faithfulness", "start", "Starting faithfulness verification"
+        )
+    except Exception:
+        pass
+
+    _, results = run_faithfulness_verification(content, sources_context, "verify")
+    data = results["faithfulness"]
+    report = format_faithfulness_report(results)
+
+    base_name = os.path.splitext(file)[0]
+    status = "[VERIFIED]" if data["flagged_count"] == 0 else "[WARNING]"
+
+    report_file = save_command_output(
+        f"{output}_faithfulness" if output else "verify_faithfulness",
+        report,
+        "" if output else os.path.basename(base_name),
+        metadata={
+            "Type": "Faithfulness",
+            "File": file,
+            "Score": f"{data['score']}/100",
+            "Flagged": str(data["flagged_count"]),
+            "Status": status,
+        },
+    )
+
+    # Save the corrective addendum as a SEPARATE file when one was produced. The
+    # original document is never rewritten.
+    addendum_file = None
+    if data.get("addendum"):
+        addendum_file = save_command_output(
+            f"{output}_faithfulness_addendum"
+            if output
+            else "verify_faithfulness_addendum",
+            data["addendum"],
+            "" if output else os.path.basename(base_name),
+            metadata={
+                "Type": "Faithfulness Addendum",
+                "File": file,
+                "Status": "[ADDENDUM]",
+            },
+        )
+
+    click.echo(f"\n{status} Faithfulness check complete")
+    click.echo(f"   - Score: {data['score']}/100")
+    click.echo(f"   - {data['flagged_count']} claim(s) flagged")
+    click.echo(f"   - Details: {report_file}")
+    if addendum_file:
+        click.echo(f"   - Addendum: {addendum_file}")
+
+    try:
+        log_task_event(
+            "verify",
+            "faithfulness",
+            "end",
+            f"Faithfulness check complete - score {data['score']}, {data['flagged_count']} flagged",
+        )
+    except Exception:
+        pass
+
+    return data, data["score"], report_file, addendum_file

--- a/litassist/llm/model_configs.yaml
+++ b/litassist/llm/model_configs.yaml
@@ -294,3 +294,34 @@ cove-final:
   thinking_effort: "medium"
   enforce_citations: false
   disable_tools: true
+
+# --- P-FAITH faithfulness check (run_faithfulness_verification) ---
+faithfulness-claims:
+  # Stage 1: extracting atomic claims must be literal, not creative -> low temperature;
+  # shallow enumeration task -> low reasoning effort.
+  model: "anthropic/claude-sonnet-4.6"
+  temperature: 0.2
+  top_p: 0.3
+  thinking_effort: "low"
+  enforce_citations: false
+  disable_tools: true
+
+faithfulness-align:
+  # Stage 2: grounding each claim against the sources must be deterministic -> low
+  # temperature; careful span-level cross-checking -> high reasoning effort.
+  model: "openai/gpt-5.5"
+  temperature: 0.2
+  top_p: 0.3
+  thinking_effort: "high"
+  enforce_citations: false
+  disable_tools: true
+
+faithfulness-addendum:
+  # Stage 3: corrective drafting grounded in the sources -> low temperature, moderate
+  # effort (mirrors cove-final).
+  model: "anthropic/claude-sonnet-4.6"
+  temperature: 0.2
+  top_p: 0.4
+  thinking_effort: "medium"
+  enforce_citations: false
+  disable_tools: true

--- a/litassist/prompts/verification.yaml
+++ b/litassist/prompts/verification.yaml
@@ -308,6 +308,91 @@ verification:
 
       Generate the complete corrected version of the ORIGINAL DOCUMENT:
 
+  faithfulness:
+    # USED BY: verification_chain.py run_faithfulness_verification() - Stage 1: extract atomic claims
+    claim_extraction: |
+      Extract the atomic factual claims made in the DOCUMENT below. An atomic claim is a
+      single self-contained factual assertion - a date, amount, party name, event,
+      obligation, or characterisation of fact - that could be checked against source
+      material.
+
+      Rules:
+      - Extract only assertions of FACT made by the document. Do not extract legal
+        argument, submissions, rhetorical framing, or boilerplate.
+      - Split compound sentences into separate atomic claims.
+      - Preserve specifics verbatim (numbers, dates, names) so they can be checked.
+      - Treat an explicit placeholder (e.g. [DATE TO BE CONFIRMED], [AMOUNT TO BE
+        PROVIDED]) as its own claim - it marks deliberately missing data.
+
+      === DOCUMENT ===
+      {content}
+      === END DOCUMENT ===
+
+      Output one claim per line, numbered (1. ..., 2. ..., etc.). Output nothing else.
+
+    # USED BY: verification_chain.py run_faithfulness_verification() - Stage 2: classify each claim against the sources
+    alignment: |
+      Check whether each CLAIM below is grounded in the SOURCE DOCUMENTS. The source
+      documents are the ground truth.
+
+      Classify every claim as exactly one of:
+      - SUPPORTED: directly supported by a span in the source documents.
+      - UNSUPPORTED: a specific factual assertion that is NOT found in the source
+        documents (neither supported nor contradicted).
+      - CONTRADICTED: the source documents state something inconsistent with the claim.
+      - PLACEHOLDER: an explicit placeholder for missing data (e.g. [DATE TO BE
+        CONFIRMED]); not a factual assertion to ground.
+
+      === SOURCE DOCUMENTS ===
+      {sources}
+      === END SOURCE DOCUMENTS ===
+
+      === CLAIMS ===
+      {claims}
+      === END CLAIMS ===
+
+      Output one block per claim, in the same order, using exactly these three lines per
+      block and nothing else:
+      CLAIM: <the claim text>
+      CLASSIFICATION: <one of SUPPORTED, UNSUPPORTED, CONTRADICTED, PLACEHOLDER>
+      SOURCE: <quote the supporting or contradicting span from the source documents, or "none">
+
+      The CLASSIFICATION line must contain exactly one of those four words and nothing
+      else - not the list, not a slash-separated set. Emit exactly one CLASSIFICATION
+      line per claim. Do not add any commentary before or after the blocks.
+
+    # USED BY: verification_chain.py run_faithfulness_verification() - Stage 3: corrective addendum (only when claims are flagged)
+    addendum: |
+      The faithfulness check found claims in the ORIGINAL DOCUMENT that are not grounded
+      in the source documents. Write a standalone CORRECTIVE ADDENDUM that addresses ONLY
+      the flagged claims.
+
+      CRITICAL:
+      - Do NOT reproduce, rewrite, or restate the original document. Output the addendum
+        only.
+      - For each flagged claim, state the problem (unsupported by, or contradicted by, the
+        sources) and the correction: either the correct fact drawn from the sources, or an
+        explicit placeholder (e.g. [DATE TO BE CONFIRMED], [AMOUNT TO BE PROVIDED]) when
+        the sources do not supply it.
+      - Never invent specifics. If the sources do not establish a fact, use a placeholder;
+        do not guess.
+      - Use Australian English spelling.
+
+      === FLAGGED CLAIMS ===
+      {flagged}
+      === END FLAGGED CLAIMS ===
+
+      === SOURCE DOCUMENTS ===
+      {sources}
+      === END SOURCE DOCUMENTS ===
+
+      === ORIGINAL DOCUMENT (for reference only - do not reproduce) ===
+      {content}
+      === END ORIGINAL DOCUMENT ===
+
+      Output a titled addendum: a short heading, then one entry per flagged claim (the
+      claim, the issue, and the correction).
+
   # Base Australian law prompt
   # USED BY: llm.py LLMClient.verify() method - base prompt
   # LOCATION: llm.py:1302 (previously fallback, now required)

--- a/litassist/prompts/verification.yaml
+++ b/litassist/prompts/verification.yaml
@@ -336,12 +336,26 @@ verification:
       documents are the ground truth.
 
       Classify every claim as exactly one of:
-      - SUPPORTED: directly supported by a span in the source documents.
-      - UNSUPPORTED: a specific factual assertion that is NOT found in the source
-        documents (neither supported nor contradicted).
+      - SUPPORTED: the source documents establish the same fact, whether in the same
+        words or as a faithful restatement. A paraphrase, a change of voice
+        (active/passive), a synonym, or a reordering does NOT make a claim
+        unsupported. The test is whether the source establishes the fact, not whether
+        the wording matches. Where the source states a fact passively (an event that
+        was to happen) and the claim attributes it to the party the source plainly
+        identifies by role or context, that is still SUPPORTED.
+      - UNSUPPORTED: the claim introduces a specific - a date, figure, name, or event -
+        that the source documents do not establish, directly or by faithful
+        restatement. Do not flag a claim merely because its wording differs from the
+        source.
       - CONTRADICTED: the source documents state something inconsistent with the claim.
       - PLACEHOLDER: an explicit placeholder for missing data (e.g. [DATE TO BE
         CONFIRMED]); not a factual assertion to ground.
+
+      A faithful restatement is SUPPORTED, not unsupported. For example, if a source
+      span reads "The goods were to be delivered by 15 March 2020" and the claim reads
+      "The defendant was required to deliver the goods by 15 March 2020", classify it
+      SUPPORTED and quote that span - the delivery obligation and date are the same
+      fact stated in different words.
 
       === SOURCE DOCUMENTS ===
       {sources}

--- a/litassist/verification_chain.py
+++ b/litassist/verification_chain.py
@@ -626,6 +626,14 @@ def format_cove_report(cove_results: Dict) -> str:
 # pure scorer can validate its input and fail loud on anything else.
 _FAITHFULNESS_LABELS = ("SUPPORTED", "UNSUPPORTED", "CONTRADICTED", "PLACEHOLDER")
 
+# Matches the alignment stage's per-claim classification line. One match per claim is
+# the authoritative count for scoring; a malformed response yields zero matches and is
+# failed closed by the orchestrator (no silent score-100).
+_CLASSIFICATION_RE = re.compile(
+    r"^CLASSIFICATION:\s*(SUPPORTED|UNSUPPORTED|CONTRADICTED|PLACEHOLDER)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 
 def score_faithfulness(classifications) -> Dict:
     """Aggregate per-claim faithfulness labels into a deterministic score.
@@ -665,3 +673,193 @@ def score_faithfulness(classifications) -> Dict:
         "flagged_count": unsupported + contradicted,
         "total": len(classifications),
     }
+
+
+def _flagged_blocks(alignment: str) -> str:
+    """Return the alignment blocks classified UNSUPPORTED or CONTRADICTED, joined.
+
+    Splits on each ``CLAIM:`` line so blocks stay intact; used only to feed the addendum
+    prompt. The authoritative score comes from ``_CLASSIFICATION_RE`` counts, not this.
+    """
+    flagged = []
+    for block in re.split(r"(?im)^(?=CLAIM:)", alignment):
+        match = _CLASSIFICATION_RE.search(block)
+        if match and match.group(1).upper() in ("UNSUPPORTED", "CONTRADICTED"):
+            flagged.append(block.strip())
+    return "\n\n".join(flagged)
+
+
+def run_faithfulness_verification(
+    content: str, sources_context: str, command: str
+) -> Tuple[str, Dict]:
+    """Check whether the document's factual claims are grounded in the source documents.
+
+    Three stages mirroring run_cove_verification: extract atomic claims, classify each
+    against the sources, and -- only when claims are flagged -- draft a standalone
+    corrective addendum. The original ``content`` is NEVER modified; it is returned
+    unchanged. Returns (content, results) where ``results["faithfulness"]`` carries the
+    score, per-claim classifications, the flagged blocks, and the addendum (or None).
+    """
+    client_claims = LLMClientFactory.for_command("faithfulness-claims")
+    client_align = LLMClientFactory.for_command("faithfulness-align")
+    stages = {}
+
+    # Stage 1: extract atomic claims from the document under test.
+    claims_prompt = PROMPTS.get("verification.faithfulness.claim_extraction").format(
+        content=content
+    )
+    log_task_event(command, "faithfulness-claims", "start", "Extracting atomic claims")
+    client_claims.command_context = f"faithfulness_stage1_claims_{command}"
+    claims, usage1 = client_claims.complete(
+        [{"role": "user", "content": claims_prompt}]
+    )
+    log_task_event(
+        command,
+        "faithfulness-claims",
+        "llm_response",
+        "Received atomic claims",
+        {"model": client_claims.model, "response_length": len(claims), "usage": usage1},
+    )
+    stages["claims"] = {
+        "prompt": claims_prompt,
+        "response": claims,
+        "usage": usage1,
+        "model": client_claims.model,
+    }
+
+    # No substantive claims -> nothing to ground; faithful by definition.
+    if not claims.strip():
+        score_data = score_faithfulness([])
+        results = {
+            "faithfulness": {
+                **score_data,
+                "claims": claims,
+                "alignment": "",
+                "flagged_text": "",
+                "addendum": None,
+            }
+        }
+        save_log(
+            f"faithfulness_{command}_summary",
+            {
+                "command": command,
+                "stages": stages,
+                "result": score_data,
+                "addendum_generated": False,
+                "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            },
+        )
+        return content, results
+
+    # Stage 2: classify each claim against the sources.
+    align_prompt = PROMPTS.get("verification.faithfulness.alignment").format(
+        sources=sources_context, claims=claims
+    )
+    log_task_event(
+        command, "faithfulness-align", "start", "Classifying claims against sources"
+    )
+    client_align.command_context = f"faithfulness_stage2_align_{command}"
+    alignment, usage2 = client_align.complete(
+        [{"role": "user", "content": align_prompt}]
+    )
+    log_task_event(
+        command,
+        "faithfulness-align",
+        "llm_response",
+        "Received claim classifications",
+        {"model": client_align.model, "response_length": len(alignment), "usage": usage2},
+    )
+    stages["alignment"] = {
+        "prompt": align_prompt,
+        "response": alignment,
+        "usage": usage2,
+        "model": client_align.model,
+    }
+
+    labels = [m.group(1).upper() for m in _CLASSIFICATION_RE.finditer(alignment)]
+    # Fail closed: claims were extracted but the alignment stage produced no parseable
+    # classification line, so the contract was not met. Do not silently score 100.
+    if not labels:
+        raise ValueError(
+            "Faithfulness alignment returned no parseable CLASSIFICATION lines"
+        )
+
+    score_data = score_faithfulness(labels)
+    flagged_text = _flagged_blocks(alignment)
+
+    # Stage 3: corrective addendum, only when claims are flagged. The original document
+    # is left untouched -- the addendum is a separate artifact.
+    addendum = None
+    if score_data["flagged_count"] > 0:
+        client_addendum = LLMClientFactory.for_command("faithfulness-addendum")
+        addendum_prompt = PROMPTS.get("verification.faithfulness.addendum").format(
+            flagged=flagged_text, sources=sources_context, content=content
+        )
+        log_task_event(
+            command, "faithfulness-addendum", "start", "Drafting corrective addendum"
+        )
+        client_addendum.command_context = f"faithfulness_stage3_addendum_{command}"
+        addendum, usage3 = client_addendum.complete(
+            [{"role": "user", "content": addendum_prompt}]
+        )
+        log_task_event(
+            command,
+            "faithfulness-addendum",
+            "llm_response",
+            "Received corrective addendum",
+            {
+                "model": client_addendum.model,
+                "response_length": len(addendum),
+                "usage": usage3,
+            },
+        )
+        stages["addendum"] = {
+            "prompt": addendum_prompt,
+            "response": addendum,
+            "usage": usage3,
+            "model": client_addendum.model,
+        }
+
+    results = {
+        "faithfulness": {
+            **score_data,
+            "claims": claims,
+            "alignment": alignment,
+            "flagged_text": flagged_text,
+            "addendum": addendum,
+        }
+    }
+
+    save_log(
+        f"faithfulness_{command}_summary",
+        {
+            "command": command,
+            "stages": stages,
+            "result": score_data,
+            "addendum_generated": addendum is not None,
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+        },
+    )
+
+    return content, results
+
+
+def format_faithfulness_report(results: Dict) -> str:
+    """Format faithfulness results into a readable report."""
+    data = results.get("faithfulness", {})
+    lines = [
+        "## Faithfulness Report\n",
+        f"**Score**: {data.get('score', 0)}/100",
+        "",
+        f"- Supported: {data.get('supported', 0)}",
+        f"- Unsupported: {data.get('unsupported', 0)}",
+        f"- Contradicted: {data.get('contradicted', 0)}",
+        f"- Placeholder (neutral): {data.get('placeholder', 0)}",
+        "",
+        "### Per-claim classification",
+        data.get("alignment") or "No claims extracted.",
+        "",
+        "### Flagged claims (unsupported or contradicted)",
+        data.get("flagged_text") or "None",
+    ]
+    return "\n".join(lines)

--- a/litassist/verification_chain.py
+++ b/litassist/verification_chain.py
@@ -776,12 +776,16 @@ def run_faithfulness_verification(
         "model": client_align.model,
     }
 
+    # Count the claims stage 1 extracted (the prompt numbers them "1. ", "2. ", ...).
+    claim_count = len(re.findall(r"(?m)^\s*\d+\.", claims))
     labels = [m.group(1).upper() for m in _CLASSIFICATION_RE.finditer(alignment)]
-    # Fail closed: claims were extracted but the alignment stage produced no parseable
-    # classification line, so the contract was not met. Do not silently score 100.
-    if not labels:
+    # Fail closed unless EVERY extracted claim was classified. A partial alignment
+    # (fewer classifications than claims) must not score as fully faithful: an ungraded
+    # claim could be unsupported or contradicted, so a missing grade is silent risk.
+    if not labels or len(labels) < claim_count:
         raise ValueError(
-            "Faithfulness alignment returned no parseable CLASSIFICATION lines"
+            f"Faithfulness alignment classified {len(labels)} of {claim_count} claims; "
+            "expected one classification per extracted claim"
         )
 
     score_data = score_faithfulness(labels)

--- a/litassist/verification_chain.py
+++ b/litassist/verification_chain.py
@@ -618,3 +618,50 @@ def format_cove_report(cove_results: Dict) -> str:
     ]
 
     return "\n".join(lines)
+
+
+# --- P-FAITH: faithfulness scoring -----------------------------------------
+
+# The four labels the alignment stage may assign to a claim. Kept as a set so the
+# pure scorer can validate its input and fail loud on anything else.
+_FAITHFULNESS_LABELS = ("SUPPORTED", "UNSUPPORTED", "CONTRADICTED", "PLACEHOLDER")
+
+
+def score_faithfulness(classifications) -> Dict:
+    """Aggregate per-claim faithfulness labels into a deterministic score.
+
+    Each entry in ``classifications`` is one of SUPPORTED / UNSUPPORTED /
+    CONTRADICTED / PLACEHOLDER (case-insensitive). Pure -- no I/O -- so it is directly
+    unit-testable offline.
+
+    PLACEHOLDER claims use the project's sanctioned ``[... TO BE PROVIDED]`` convention
+    for missing data, so they are NEUTRAL and excluded from the denominator. The score
+    is the fraction of *substantive* claims (supported + unsupported + contradicted)
+    that are grounded in the sources; with no substantive claims the score is 100.
+    """
+    counts = {label: 0 for label in _FAITHFULNESS_LABELS}
+    for label in classifications:
+        key = label.strip().upper()
+        if key not in counts:
+            raise ValueError(f"Unknown faithfulness label: {label!r}")
+        counts[key] += 1
+
+    supported = counts["SUPPORTED"]
+    unsupported = counts["UNSUPPORTED"]
+    contradicted = counts["CONTRADICTED"]
+    placeholder = counts["PLACEHOLDER"]
+
+    # Denominator excludes placeholders (correctly-marked missing data, not a grounding
+    # failure); 100 when nothing substantive needs grounding.
+    substantive = supported + unsupported + contradicted
+    score = round(100 * supported / substantive) if substantive else 100
+
+    return {
+        "score": score,
+        "supported": supported,
+        "unsupported": unsupported,
+        "contradicted": contradicted,
+        "placeholder": placeholder,
+        "flagged_count": unsupported + contradicted,
+        "total": len(classifications),
+    }

--- a/litassist/verification_chain.py
+++ b/litassist/verification_chain.py
@@ -779,10 +779,11 @@ def run_faithfulness_verification(
     # Count the claims stage 1 extracted (the prompt numbers them "1. ", "2. ", ...).
     claim_count = len(re.findall(r"(?m)^\s*\d+\.", claims))
     labels = [m.group(1).upper() for m in _CLASSIFICATION_RE.finditer(alignment)]
-    # Fail closed unless EVERY extracted claim was classified. A partial alignment
-    # (fewer classifications than claims) must not score as fully faithful: an ungraded
-    # claim could be unsupported or contradicted, so a missing grade is silent risk.
-    if not labels or len(labels) < claim_count:
+    # Fail closed unless the classifications match the extracted claims one-to-one.
+    # Fewer labels means an ungraded claim (which could be unsupported or contradicted);
+    # more labels means the grader classified something that was never extracted. Either
+    # way the counts cannot be trusted, so a mismatch is an error, not a score.
+    if not labels or len(labels) != claim_count:
         raise ValueError(
             f"Faithfulness alignment classified {len(labels)} of {claim_count} claims; "
             "expected one classification per extracted claim"

--- a/test-scripts/test_cli_comprehensive.sh
+++ b/test-scripts/test_cli_comprehensive.sh
@@ -589,6 +589,13 @@ test_verify_command() {
         "litassist verify test_inputs/mock_case_facts.txt --citations --soundness --reasoning --cove --reference 'test_inputs/*.txt' --cove-reference 'test_inputs/*.txt' --heavy --output test_output" \
         "Citation verification complete|Legal soundness check complete" \
         "yes"
+
+    # --faithfulness is opt-in and requires --reference (the source documents the
+    # document's claims are checked against). Runs only the faithfulness stage.
+    run_test "Verify - Faithfulness (claims grounded in --reference sources)" \
+        "litassist verify test_inputs/mock_case_facts.txt --faithfulness --reference 'test_inputs/*.txt' --output test_output" \
+        "Faithfulness check complete" \
+        "yes"
 }
 
 test_counselnotes_command() {

--- a/tests/unit/test_faithfulness_handler.py
+++ b/tests/unit/test_faithfulness_handler.py
@@ -1,0 +1,64 @@
+"""Tests for verify_faithfulness handler (P-FAITH).
+
+Pins the user-facing contract that the corrective addendum is saved as a SEPARATE
+file and only when claims are flagged -- the original document is never rewritten.
+The orchestrator is mocked; only the handler's save/return behaviour is exercised.
+"""
+
+from unittest.mock import patch
+
+from litassist.commands.verify.faithfulness_handler import verify_faithfulness
+
+
+def _results(flagged_count, addendum):
+    data = {
+        "score": 50 if flagged_count else 100,
+        "supported": 1,
+        "unsupported": flagged_count,
+        "contradicted": 0,
+        "placeholder": 0,
+        "flagged_count": flagged_count,
+        "total": 1 + flagged_count,
+        "claims": "1. a claim",
+        "alignment": "CLAIM: a claim\nCLASSIFICATION: SUPPORTED\nSOURCE: none",
+        "flagged_text": "CLAIM: bad\nCLASSIFICATION: UNSUPPORTED" if flagged_count else "",
+        "addendum": addendum,
+    }
+    return ("DOC", {"faithfulness": data})
+
+
+def _run(flagged_count, addendum):
+    with patch(
+        "litassist.commands.verify.faithfulness_handler.run_faithfulness_verification",
+        return_value=_results(flagged_count, addendum),
+    ), patch(
+        "litassist.commands.verify.faithfulness_handler.save_command_output",
+        side_effect=lambda prefix, content, slug, metadata=None: f"/out/{prefix}.md",
+    ) as mock_save, patch(
+        "litassist.commands.verify.faithfulness_handler.log_task_event"
+    ):
+        result = verify_faithfulness("DOC", "doc.md", "SOURCES")
+    return result, mock_save
+
+
+def test_addendum_saved_as_separate_file_when_flagged():
+    (data, score, report_file, addendum_file), mock_save = _run(1, "ADDENDUM TEXT")
+
+    assert mock_save.call_count == 2
+    assert addendum_file is not None
+    prefixes = [call.args[0] for call in mock_save.call_args_list]
+    assert "verify_faithfulness" in prefixes
+    assert "verify_faithfulness_addendum" in prefixes
+    # The addendum file content is the addendum text, not a rewritten document.
+    addendum_call = next(
+        c for c in mock_save.call_args_list if c.args[0] == "verify_faithfulness_addendum"
+    )
+    assert addendum_call.args[1] == "ADDENDUM TEXT"
+
+
+def test_no_addendum_when_nothing_flagged():
+    (data, score, report_file, addendum_file), mock_save = _run(0, None)
+
+    assert mock_save.call_count == 1  # report only
+    assert addendum_file is None
+    assert score == 100

--- a/tests/unit/test_faithfulness_scoring.py
+++ b/tests/unit/test_faithfulness_scoring.py
@@ -1,0 +1,96 @@
+"""Tests for score_faithfulness (P-FAITH deterministic scoring core).
+
+The faithfulness checker classifies each atomic claim in a verified document against
+the supplied source documents as one of SUPPORTED / UNSUPPORTED / CONTRADICTED /
+PLACEHOLDER. This pure function aggregates those per-claim labels into a single
+auditable score, with no I/O, so it is directly unit-testable offline (mirrors the
+P-JUDGE pure-scoring-core pattern).
+
+Scoring contract:
+- PLACEHOLDER claims (the sanctioned `[... TO BE PROVIDED]` convention) are NEUTRAL and
+  excluded from the score denominator -- they are correctly-marked missing data, not a
+  faithfulness failure.
+- score = round(100 * supported / (supported + unsupported + contradicted)); when that
+  denominator is 0 the score is 100 (nothing substantive to ground).
+- flagged_count = unsupported + contradicted (the claims that drive the report's flagged
+  section and gate addendum generation).
+"""
+
+import pytest
+
+from litassist.verification_chain import score_faithfulness
+
+
+def test_all_supported_scores_100():
+    result = score_faithfulness(["SUPPORTED", "SUPPORTED", "SUPPORTED"])
+    assert result["score"] == 100
+    assert result["supported"] == 3
+    assert result["flagged_count"] == 0
+
+
+def test_mixed_counts_round_to_nearest_percent():
+    # 2 of 3 substantive claims grounded -> round(100 * 2/3) == 67.
+    result = score_faithfulness(["SUPPORTED", "SUPPORTED", "UNSUPPORTED"])
+    assert result["score"] == 67
+    assert result["supported"] == 2
+    assert result["unsupported"] == 1
+    assert result["flagged_count"] == 1
+
+
+def test_contradicted_counts_as_flagged_and_lowers_score():
+    result = score_faithfulness(["SUPPORTED", "CONTRADICTED"])
+    assert result["score"] == 50
+    assert result["contradicted"] == 1
+    # Both unsupported and contradicted feed the flagged set.
+    assert result["flagged_count"] == 1
+
+
+def test_placeholders_are_neutral_excluded_from_denominator():
+    # 2 supported, 2 placeholder -> denominator is 2, not 4; score is 100.
+    result = score_faithfulness(
+        ["SUPPORTED", "PLACEHOLDER", "SUPPORTED", "PLACEHOLDER"]
+    )
+    assert result["score"] == 100
+    assert result["placeholder"] == 2
+    assert result["supported"] == 2
+    assert result["flagged_count"] == 0
+
+
+def test_placeholder_beside_failing_claim_stays_neutral():
+    # A placeholder next to a failing claim must not change the score: denominator is
+    # the two substantive claims (1 supported, 1 unsupported) -> 50, one flagged. The
+    # lowercase label also pins case-insensitivity for PLACEHOLDER specifically.
+    result = score_faithfulness(["SUPPORTED", "UNSUPPORTED", "placeholder"])
+    assert result["score"] == 50
+    assert result["flagged_count"] == 1
+    assert result["placeholder"] == 1
+
+
+def test_all_placeholder_denominator_zero_scores_100():
+    # Nothing substantive to ground -> score 100, no flags.
+    result = score_faithfulness(["PLACEHOLDER", "PLACEHOLDER"])
+    assert result["score"] == 100
+    assert result["flagged_count"] == 0
+
+
+def test_empty_input_scores_100():
+    result = score_faithfulness([])
+    assert result["score"] == 100
+    assert result["supported"] == 0
+    assert result["flagged_count"] == 0
+
+
+def test_labels_normalised_case_insensitively():
+    result = score_faithfulness(["supported", "Unsupported", "contradicted"])
+    assert result["supported"] == 1
+    assert result["unsupported"] == 1
+    assert result["contradicted"] == 1
+    assert result["flagged_count"] == 2
+
+
+def test_unknown_label_raises():
+    # The upstream parse restricts labels to the four valid tokens; an unknown label
+    # is a contract violation, so the pure function fails loud rather than silently
+    # miscounting.
+    with pytest.raises(ValueError):
+        score_faithfulness(["SUPPORTED", "MAYBE"])

--- a/tests/unit/test_faithfulness_verification.py
+++ b/tests/unit/test_faithfulness_verification.py
@@ -122,6 +122,17 @@ def test_malformed_alignment_fails_closed():
         _run(mapping)
 
 
+def test_partial_alignment_fails_closed():
+    # Stage 1 extracts three claims but the alignment classifies only one. The two
+    # ungraded claims could be unsupported/contradicted, so a partial alignment must
+    # NOT score as fully faithful -- it fails closed.
+    claims = "1. claim one\n2. claim two\n3. claim three"
+    alignment = "CLAIM: claim one\nCLASSIFICATION: SUPPORTED\nSOURCE: none\n"
+    mapping = _clients(claims, alignment)
+    with pytest.raises(ValueError):
+        _run(mapping)
+
+
 def test_no_claims_skips_alignment_and_is_faithful():
     mapping = _clients("   ", "unused")
     content, results = _run(mapping)

--- a/tests/unit/test_faithfulness_verification.py
+++ b/tests/unit/test_faithfulness_verification.py
@@ -133,6 +133,20 @@ def test_partial_alignment_fails_closed():
         _run(mapping)
 
 
+def test_surplus_alignment_fails_closed():
+    # Stage 1 extracts one claim but the alignment returns two classifications: the
+    # grader graded something that was not an extracted claim, so the counts cannot
+    # be trusted and the run must fail closed, not score the phantom label.
+    claims = "1. claim one"
+    alignment = (
+        "CLAIM: claim one\nCLASSIFICATION: SUPPORTED\nSOURCE: none\n\n"
+        "CLAIM: phantom claim\nCLASSIFICATION: SUPPORTED\nSOURCE: none\n"
+    )
+    mapping = _clients(claims, alignment)
+    with pytest.raises(ValueError):
+        _run(mapping)
+
+
 def test_no_claims_skips_alignment_and_is_faithful():
     mapping = _clients("   ", "unused")
     content, results = _run(mapping)

--- a/tests/unit/test_faithfulness_verification.py
+++ b/tests/unit/test_faithfulness_verification.py
@@ -1,0 +1,136 @@
+"""Tests for run_faithfulness_verification (P-FAITH orchestrator).
+
+The faithfulness checker runs three staged LLM calls (extract atomic claims -> classify
+each against the supplied sources -> draft a corrective addendum when claims are
+flagged). These tests mock the stage clients at the LLMClientFactory boundary (the same
+pattern as the CoVe tests) and assert the staged control flow:
+
+- the original document is NEVER modified (the addendum is a separate artifact);
+- the addendum stage runs ONLY when there are flagged (unsupported/contradicted) claims;
+- a malformed alignment response (no CLASSIFICATION lines) fails closed rather than
+  silently scoring 100;
+- a document with no extractable claims is faithful by definition and skips alignment.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from litassist.verification_chain import run_faithfulness_verification
+
+_MOCK_MODEL = "test/mock-model"
+_DOC = "The contract was signed on 1 March 2020. The settlement sum was $5,000."
+_SOURCES = "Deed dated 1 March 2020. Settlement sum: $5,000."
+
+
+def _clients(claims_text, alignment_text, addendum_text="ADDENDUM"):
+    """Build mock stage clients keyed by role name."""
+    claims_client = Mock(model=_MOCK_MODEL)
+    claims_client.complete.return_value = (claims_text, {"total_tokens": 10})
+    align_client = Mock(model=_MOCK_MODEL)
+    align_client.complete.return_value = (alignment_text, {"total_tokens": 20})
+    addendum_client = Mock(model=_MOCK_MODEL)
+    addendum_client.complete.return_value = (addendum_text, {"total_tokens": 30})
+    mapping = {
+        "faithfulness-claims": claims_client,
+        "faithfulness-align": align_client,
+        "faithfulness-addendum": addendum_client,
+    }
+    return mapping
+
+
+def _run(mapping, doc=_DOC, sources=_SOURCES):
+    with patch("litassist.verification_chain.LLMClientFactory") as factory, patch(
+        "litassist.verification_chain.save_log"
+    ), patch("litassist.verification_chain.log_task_event"):
+        factory.for_command.side_effect = lambda role: mapping[role]
+        content, results = run_faithfulness_verification(doc, sources, "verify")
+    return content, results
+
+
+def test_all_supported_no_addendum_original_unchanged():
+    alignment = (
+        "CLAIM: The contract was signed on 1 March 2020.\n"
+        "CLASSIFICATION: SUPPORTED\n"
+        'SOURCE: "Deed dated 1 March 2020"\n\n'
+        "CLAIM: The settlement sum was $5,000.\n"
+        "CLASSIFICATION: SUPPORTED\n"
+        'SOURCE: "Settlement sum: $5,000"\n'
+    )
+    mapping = _clients("1. signed 1 March 2020\n2. sum $5,000", alignment)
+    content, results = _run(mapping)
+
+    data = results["faithfulness"]
+    assert content == _DOC  # original never modified
+    assert data["score"] == 100
+    assert data["flagged_count"] == 0
+    assert data["addendum"] is None
+    # The addendum stage must not run when nothing is flagged.
+    mapping["faithfulness-addendum"].complete.assert_not_called()
+
+
+def test_unsupported_claim_triggers_addendum_and_lowers_score():
+    alignment = (
+        "CLAIM: The contract was signed on 1 March 2020.\n"
+        "CLASSIFICATION: SUPPORTED\n"
+        'SOURCE: "Deed dated 1 March 2020"\n\n'
+        "CLAIM: The settlement sum was $5,000.\n"
+        "CLASSIFICATION: UNSUPPORTED\n"
+        "SOURCE: none\n"
+    )
+    mapping = _clients(
+        "1. signed 1 March 2020\n2. sum $5,000", alignment, addendum_text="CORRECTION NOTE"
+    )
+    content, results = _run(mapping)
+
+    data = results["faithfulness"]
+    assert content == _DOC  # still unchanged -- correction is the addendum, not a rewrite
+    assert data["score"] == 50
+    assert data["flagged_count"] == 1
+    assert data["addendum"] == "CORRECTION NOTE"
+    # The flagged block fed to the addendum is the unsupported claim, not the supported one.
+    assert "settlement sum was $5,000" in data["flagged_text"]
+    assert "1 March 2020" not in data["flagged_text"]
+    mapping["faithfulness-addendum"].complete.assert_called_once()
+
+
+def test_contradicted_claim_is_flagged_and_reaches_addendum():
+    # CONTRADICTED is a flagged label distinct from UNSUPPORTED: it too must lower the
+    # score and be the block passed to the addendum.
+    alignment = (
+        "CLAIM: The settlement sum was $5,000.\n"
+        "CLASSIFICATION: CONTRADICTED\n"
+        'SOURCE: "Settlement sum: $8,000"\n'
+    )
+    mapping = _clients("1. sum $5,000", alignment, addendum_text="CORRECTION NOTE")
+    content, results = _run(mapping)
+
+    data = results["faithfulness"]
+    assert content == _DOC
+    assert data["score"] == 0
+    assert data["contradicted"] == 1
+    assert data["flagged_count"] == 1
+    assert "settlement sum was $5,000" in data["flagged_text"]
+    assert data["addendum"] == "CORRECTION NOTE"
+    mapping["faithfulness-addendum"].complete.assert_called_once()
+
+
+def test_malformed_alignment_fails_closed():
+    # Claims were extracted but the alignment response has no CLASSIFICATION line.
+    mapping = _clients("1. a claim", "I was unable to classify these claims.")
+    with pytest.raises(ValueError):
+        _run(mapping)
+
+
+def test_no_claims_skips_alignment_and_is_faithful():
+    mapping = _clients("   ", "unused")
+    content, results = _run(mapping)
+
+    data = results["faithfulness"]
+    assert content == _DOC
+    assert data["score"] == 100
+    assert data["flagged_count"] == 0
+    assert data["addendum"] is None
+    # With no claims, neither alignment nor addendum should be invoked.
+    mapping["faithfulness-align"].complete.assert_not_called()
+    mapping["faithfulness-addendum"].complete.assert_not_called()

--- a/tests/unit/test_verify_command.py
+++ b/tests/unit/test_verify_command.py
@@ -261,6 +261,40 @@ class TestVerifyCommand:
                 mock_wf.assert_called_once()
                 assert mock_wf.call_args.kwargs["file"] == newer
 
+    def test_verify_faithfulness_requires_reference(self, runner):
+        """--faithfulness without --reference fails fast before any workflow runs."""
+        with runner.isolated_filesystem():
+            with open("doc.txt", "w") as fh:
+                fh.write("some content")
+            with patch(
+                "litassist.commands.verify.run_verification_workflow"
+            ) as mock_wf:
+                result = runner.invoke(verify, ["doc.txt", "--faithfulness"])
+                assert result.exit_code != 0
+                assert "--faithfulness requires --reference" in result.output
+                mock_wf.assert_not_called()
+
+    def test_verify_faithfulness_only_does_not_enable_default_stages(self, runner):
+        """verify FILE --faithfulness --reference runs ONLY faithfulness, leaving the
+        default three (citations/soundness/reasoning) off."""
+        with runner.isolated_filesystem():
+            with open("doc.txt", "w") as fh:
+                fh.write("some content")
+            with open("sources.txt", "w") as fh:
+                fh.write("ground truth")
+            with patch(
+                "litassist.commands.verify.run_verification_workflow"
+            ) as mock_wf:
+                result = runner.invoke(
+                    verify, ["doc.txt", "--faithfulness", "--reference", "sources.txt"]
+                )
+                assert result.exit_code == 0, result.output
+                kwargs = mock_wf.call_args.kwargs
+                assert kwargs["faithfulness"] is True
+                assert kwargs["citations"] is False
+                assert kwargs["soundness"] is False
+                assert kwargs["reasoning"] is False
+
     def testformat_citation_report(self):
         """Test citation report formatting."""
         verified = ["Case1 [2020] HCA 1", "Case2 [2021] FCA 2"]

--- a/tests/unit/test_verify_command.py
+++ b/tests/unit/test_verify_command.py
@@ -320,6 +320,48 @@ class TestVerifyCommand:
                 )
             mock_faith.assert_not_called()
 
+    def test_cove_runs_when_citations_paired_with_faithfulness(self, tmp_path):
+        """--citations --faithfulness --cove is not a citations-only run: the
+        requested CoVe stage must execute, not be skipped."""
+        from litassist.commands.verify.core import run_verification_workflow
+
+        doc = tmp_path / "doc.txt"
+        doc.write_text("The contract was signed on 1 March 2020.")
+        src = tmp_path / "src.txt"
+        src.write_text("Deed dated 1 March 2020.")
+        with patch(
+            "litassist.commands.verify.core.verify_citations"
+        ) as mock_cit, patch(
+            "litassist.commands.verify.core.verify_faithfulness"
+        ) as mock_faith, patch(
+            "litassist.commands.verify.core.run_cove_verification"
+        ) as mock_cove, patch(
+            "litassist.commands.verify.core.format_cove_report"
+        ), patch(
+            "litassist.commands.verify.core.save_command_output"
+        ) as mock_save, patch(
+            "litassist.commands.verify.core.save_log"
+        ), patch(
+            "litassist.commands.verify.core.log_task_event"
+        ):
+            mock_cit.return_value = ("report", {}, "cit.txt", [], [])
+            mock_faith.return_value = ({}, 100, "faith.txt", None)
+            mock_cove.return_value = (
+                "content",
+                {"cove": {"regenerated": False, "issues": None}},
+            )
+            mock_save.return_value = "cove_report.txt"
+            run_verification_workflow(
+                file=str(doc),
+                citations=True,
+                soundness=False,
+                reasoning=False,
+                cove=True,
+                faithfulness=True,
+                reference=str(src),
+            )
+            mock_cove.assert_called_once()
+
     def testformat_citation_report(self):
         """Test citation report formatting."""
         verified = ["Case1 [2020] HCA 1", "Case2 [2021] FCA 2"]

--- a/tests/unit/test_verify_command.py
+++ b/tests/unit/test_verify_command.py
@@ -295,6 +295,31 @@ class TestVerifyCommand:
                 assert kwargs["soundness"] is False
                 assert kwargs["reasoning"] is False
 
+    def test_faithfulness_fails_fast_when_reference_matches_no_files(self, tmp_path):
+        """--reference glob that matches nothing must fail before any LLM stage runs,
+        not classify every claim UNSUPPORTED against an empty source set."""
+        import click
+        from litassist.commands.verify.core import run_verification_workflow
+
+        doc = tmp_path / "doc.txt"
+        doc.write_text("The contract was signed on 1 March 2020.")
+        with patch(
+            "litassist.commands.verify.core.verify_faithfulness"
+        ) as mock_faith, patch("litassist.commands.verify.core.save_log"), patch(
+            "litassist.commands.verify.core.log_task_event"
+        ):
+            with pytest.raises(click.ClickException, match="matched no"):
+                run_verification_workflow(
+                    file=str(doc),
+                    citations=False,
+                    soundness=False,
+                    reasoning=False,
+                    cove=False,
+                    faithfulness=True,
+                    reference=str(tmp_path / "nomatch*.txt"),
+                )
+            mock_faith.assert_not_called()
+
     def testformat_citation_report(self):
         """Test citation report formatting."""
         verified = ["Case1 [2020] HCA 1", "Case2 [2021] FCA 2"]

--- a/tests/unit/test_yaml_prompt_validation.py
+++ b/tests/unit/test_yaml_prompt_validation.py
@@ -82,6 +82,9 @@ class TestYAMLPromptValidation:
             "command",
             "timestamp",
             "sources",
+            # P-FAITH faithfulness check (verification.faithfulness.*)
+            "claims",
+            "flagged",
             "option_num",
             "strategy_content",
             "option_number",


### PR DESCRIPTION
## Summary

Adds an opt-in faithfulness stage to `verify`: `litassist verify FILE --faithfulness --reference <sources>` checks that a document's factual claims are grounded in the supplied source documents. Faithfulness is a distinct failure mode from citation validity: a real, verified citation can still be misapplied to facts the sources never establish.

## Design

- **Three-stage pipeline** (mirrors the CoVe orchestrator in `verification_chain.py`):
  1. `faithfulness-claims` (Sonnet 4.6): extract atomic factual claims from the document.
  2. `faithfulness-align` (GPT-5.5): classify each claim against the sources as SUPPORTED / UNSUPPORTED / CONTRADICTED / PLACEHOLDER, with a quoted source span.
  3. `faithfulness-addendum` (Sonnet 4.6): runs only when claims are flagged; produces a standalone corrective addendum. The original document is never rewritten.
- **Deterministic scoring core**: the LLM emits per-claim labels; pure Python (`score_faithfulness`) aggregates them. Score = share of substantive claims supported; explicit `[... TO BE CONFIRMED]` placeholders are neutral (excluded from the denominator) per the project's anti-hallucination convention.
- **Fail-closed parsing**: a malformed or partial alignment (fewer classifications than extracted claims) raises rather than silently scoring faithful.
- **CLI**: reuses `--reference` as the ground-truth sources (no new flag); `--faithfulness` without `--reference` fails fast. The stage is opt-in and does not change the no-flags default (citations + soundness + reasoning).
- Outputs a per-claim report and, only when claims are flagged, a separate `verify_faithfulness_addendum` file.

## Validation

- Offline: 17 new unit tests (scoring math, staged control flow, fail-closed paths, addendum gating, original-document immutability); full suite green; ruff and yamllint clean.
- Real-API: two end-to-end runs on a fixture with two invented facts. Both invented facts (an 8% interest rate and a written admission of liability absent from the sources) were classified UNSUPPORTED, flagged, and carried into the addendum with placeholder corrections; the original file was byte-identical after the run. The final commit tunes the alignment prompt so a faithful restatement (paraphrase, active/passive voice) counts as SUPPORTED - the first run had flagged a passive-voice paraphrase as unsupported; the re-run classifies it SUPPORTED while both invented facts remain flagged.

## Docs

ROADMAP.md (P-FAITH marked shipped, stale spec corrected), TODO.md, CHANGELOG.md, docs/user/LitAssist_Reference_Manual.md (new flag, clarified `--reference` meaning, report/addendum outputs), test-scripts/test_cli_comprehensive.sh (online harness entry). docs/development/STATIC_ANALYSIS_DEBT.md records pre-existing diagnostics surfaced but not actioned during this work.